### PR TITLE
fix(export): use docx.js UMD build for browser compatibility

### DIFF
--- a/portfolio/admin.html
+++ b/portfolio/admin.html
@@ -20,7 +20,7 @@
   <!-- Export Libraries (CDN) -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
-  <script src="https://unpkg.com/docx@8.5.0/build/index.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docx@8.5.0/build/index.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Fix Word export library not loading in browser environment

## Problem
The docx.js library was loaded from CommonJS build which doesn't expose the `docx` global variable in browser.

## Solution
Changed CDN URL from:
```
https://unpkg.com/docx@8.5.0/build/index.js
```
To UMD build:
```
https://cdn.jsdelivr.net/npm/docx@8.5.0/build/index.umd.min.js
```

## Test plan
- [ ] Open `portfolio/admin.html` in browser
- [ ] Click Export dropdown
- [ ] Click "Export as Word"
- [ ] Verify file downloads successfully

Closes #7