### PR TITLE
fix(export): resolve library loading and Korean font issues

### DIFF
--- a/portfolio/admin.html
+++ b/portfolio/admin.html
@@ -17,11 +17,6 @@
   <link rel="stylesheet" href="styles.css?v=1.0.2">
   <link rel="stylesheet" href="admin/admin.css?v=1.2.0">
 
-  <!-- Export Libraries (CDN) -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/docx@8.5.0/build/index.umd.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 </head>
 <body>
   <div class="admin-container">
@@ -132,10 +127,16 @@
   <!-- Data (loaded from main portfolio) -->
   <script src="data/data.js?v=1.0.2"></script>
 
+  <!-- Export Libraries (CDN) - Must load before exporters -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docx@8.5.0/build/index.umd.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
+
   <!-- Admin Scripts -->
   <script src="admin/utils/file-handler.js?v=1.0.1"></script>
-  <script src="admin/utils/pdf-exporter.js?v=1.0.0"></script>
-  <script src="admin/utils/docx-exporter.js?v=1.0.0"></script>
+  <script src="admin/utils/pdf-exporter.js?v=1.0.1"></script>
+  <script src="admin/utils/docx-exporter.js?v=1.0.1"></script>
   <script src="admin/components/form-fields.js?v=1.0.2"></script>
   <script src="admin/components/admin-components.js?v=1.3.0"></script>
   <script src="admin/admin.js?v=1.8.0"></script>


### PR DESCRIPTION
## Summary
- Move CDN scripts to body for proper loading order
- Add dynamic Korean font (Noto Sans KR) loading for PDF export
- Use NotoSansKR font when available for proper Korean text rendering

## Changes
1. **admin.html**: Moved CDN scripts from `<head>` to `<body>` before exporter scripts
2. **pdf-exporter.js**: Added `loadKoreanFont()` method that:
   - Fetches Noto Sans KR TTF from Google Fonts
   - Converts to Base64 and registers with pdfMake.vfs
   - Sets NotoSansKR as default font when loaded

## Test plan
- [ ] Open Portfolio Admin page
- [ ] Click Export dropdown
- [ ] Test "Export as Word" - should download .docx file
- [ ] Test "Export as PDF" - should download .pdf file with Korean text properly rendered

Fixes #9