### PR TITLE
feat(export): integrate theme system into PDF and DOCX exporters

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -58,9 +58,9 @@ ASP.NET Web API와 TCP 서비스를 설계하고, WPF(MVVM + 비동기) 및 Qt/Q
 - **관리자 인터페이스**: 브라우저에서 직접 포트폴리오 콘텐츠 편집
 - **내보내기 옵션**: 포트폴리오를 PDF 또는 Word (DOCX) 형식으로 내보내기
   - 전체 포트폴리오 또는 섹션별 선택 내보내기
+  - 일관된 스타일링을 위한 테마 선택 기능 (5가지 내장 테마: Professional, Modern Dark, Minimal, Creative, Executive)
   - 내보내기 진행 표시
   - 파일명 사용자 정의
-  - 테마 스타일링 시스템 (5가지 내장 테마: Professional, Modern Dark, Minimal, Creative, Executive)
 
 포트폴리오 보기: `portfolio/index.html`
 관리자 패널 접근: `portfolio/admin.html`

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ This repository includes an interactive portfolio website with an admin interfac
 - **Admin Interface**: Edit portfolio content directly in the browser
 - **Export Options**: Export portfolio to PDF or Word (DOCX) format
   - Full portfolio or section-selective export
+  - Theme selection for consistent styling (5 built-in themes: Professional, Modern Dark, Minimal, Creative, Executive)
   - Progress indicator during export
   - Customizable filename
-  - Theme styling system (5 built-in themes: Professional, Modern Dark, Minimal, Creative, Executive)
 
 View the portfolio at: `portfolio/index.html`
 Access admin panel at: `portfolio/admin.html`

--- a/portfolio/admin/admin.js
+++ b/portfolio/admin/admin.js
@@ -1252,9 +1252,39 @@ class AdminApp {
   }
 
   /**
+   * Get available themes for export
+   * @returns {Array} Array of theme objects with id, name, description
+   */
+  getAvailableThemes() {
+    const styleManager = window.StyleManager;
+    if (styleManager && styleManager.getAllThemePreviews) {
+      return styleManager.getAllThemePreviews();
+    }
+    // Fallback themes
+    return [
+      { id: 'professional', name: 'Professional', description: 'Clean blue and gray palette' },
+      { id: 'modern-dark', name: 'Modern Dark', description: 'Sleek dark theme' },
+      { id: 'minimal', name: 'Minimal', description: 'Clean black and white' },
+      { id: 'creative', name: 'Creative', description: 'Vibrant colors' },
+      { id: 'executive', name: 'Executive', description: 'Navy and gold' }
+    ];
+  }
+
+  /**
    * Show export options modal
    */
   showExportOptionsModal() {
+    const themes = this.getAvailableThemes();
+    const themeOptions = themes.map(t => `
+      <label class="multi-select-option">
+        <input type="radio" name="export-theme" value="${t.id}" ${t.id === 'professional' ? 'checked' : ''}>
+        <div>
+          <strong>${t.name}</strong>
+          <span class="theme-desc">${t.description}</span>
+        </div>
+      </label>
+    `).join('');
+
     const modal = `
       <div class="modal-overlay" id="export-options-modal">
         <div class="modal" style="max-width: 500px;">
@@ -1274,6 +1304,12 @@ class AdminApp {
                   <input type="radio" name="export-format" value="docx">
                   Word Document
                 </label>
+              </div>
+            </div>
+            <div class="form-group">
+              <label>Theme</label>
+              <div class="multi-select theme-select">
+                ${themeOptions}
               </div>
             </div>
             <div class="form-group">
@@ -1324,6 +1360,7 @@ class AdminApp {
     modalEl.querySelector('.modal-cancel').addEventListener('click', closeModal);
     modalEl.querySelector('.modal-export').addEventListener('click', () => {
       const format = modalEl.querySelector('input[name="export-format"]:checked').value;
+      const theme = modalEl.querySelector('input[name="export-theme"]:checked')?.value || 'professional';
       const sections = Array.from(modalEl.querySelectorAll('input[name="export-section"]:checked'))
         .map(cb => cb.value);
       const filename = modalEl.querySelector('#export-filename').value || 'portfolio';
@@ -1332,7 +1369,8 @@ class AdminApp {
 
       const options = {
         sections,
-        filename: `${filename}.${format}`
+        filename: `${filename}.${format}`,
+        theme
       };
 
       if (format === 'pdf') {


### PR DESCRIPTION
## Summary
- Refactor PDFExporter and DOCXExporter to use StyleManager for theme-based styling
- Add theme selection UI to export options modal
- Support dynamic color, typography, and spacing from themes
- Add fallback styles when StyleManager is unavailable
- Update README documentation with theme selection feature

## Changes
- `portfolio/admin/utils/pdf-exporter.js`: Added theme integration with helper methods (getColor, getTypography, getSpacing, getLayout)
- `portfolio/admin/utils/docx-exporter.js`: Added theme integration with helper methods
- `portfolio/admin/admin.js`: Added getAvailableThemes() and updated showExportOptionsModal() with theme selection
- `README.md` / `README.ko.md`: Updated export options documentation

## Test plan
- [ ] Open admin panel and click Export Options
- [ ] Verify theme selection appears with all 5 themes
- [ ] Export PDF with each theme and verify styling
- [ ] Export DOCX with each theme and verify styling
- [ ] Verify fallback works when StyleManager is unavailable

Closes #12