### PR TITLE
feat(export): add theme selection UI to export options modal

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -58,7 +58,8 @@ ASP.NET Web API와 TCP 서비스를 설계하고, WPF(MVVM + 비동기) 및 Qt/Q
 - **관리자 인터페이스**: 브라우저에서 직접 포트폴리오 콘텐츠 편집
 - **내보내기 옵션**: 포트폴리오를 PDF 또는 Word (DOCX) 형식으로 내보내기
   - 전체 포트폴리오 또는 섹션별 선택 내보내기
-  - 일관된 스타일링을 위한 테마 선택 기능 (5가지 내장 테마: Professional, Modern Dark, Minimal, Creative, Executive)
+  - 시각적 미리보기가 포함된 테마 선택 기능 (5가지 내장 테마: Professional, Modern Dark, Minimal, Creative, Executive)
+  - 다음 내보내기를 위한 테마 환경설정 저장
   - 내보내기 진행 표시
   - 파일명 사용자 정의
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ This repository includes an interactive portfolio website with an admin interfac
 - **Admin Interface**: Edit portfolio content directly in the browser
 - **Export Options**: Export portfolio to PDF or Word (DOCX) format
   - Full portfolio or section-selective export
-  - Theme selection for consistent styling (5 built-in themes: Professional, Modern Dark, Minimal, Creative, Executive)
+  - Theme selection with visual preview (5 built-in themes: Professional, Modern Dark, Minimal, Creative, Executive)
+  - Theme preference saved for future exports
   - Progress indicator during export
   - Customizable filename
 

--- a/portfolio/admin/admin.css
+++ b/portfolio/admin/admin.css
@@ -1500,3 +1500,170 @@
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+/* ==========================================
+   Theme Selection UI Styles
+   ========================================== */
+
+/* Export Modal Enhancements */
+.export-modal {
+  max-width: 480px;
+}
+
+.export-modal .form-group {
+  margin-bottom: 16px;
+}
+
+.export-modal .form-group label {
+  display: block;
+  margin-bottom: 6px;
+  font-weight: 500;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.export-modal .form-select,
+.export-modal .form-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 14px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.export-modal .form-select:focus,
+.export-modal .form-input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+/* Theme Preview Container */
+.theme-preview-container {
+  margin: 12px 0 16px;
+  padding: 12px;
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+/* Theme Preview Card */
+.theme-preview-card {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.theme-preview-swatch {
+  width: 80px;
+  height: 100px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  flex-shrink: 0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.swatch-header {
+  height: 20px;
+  width: 100%;
+}
+
+.swatch-body {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.swatch-line {
+  height: 4px;
+  border-radius: 2px;
+}
+
+.swatch-accent {
+  height: 8px;
+  margin: 8px;
+  border-radius: 2px;
+}
+
+.theme-preview-info {
+  flex: 1;
+}
+
+.theme-name {
+  margin: 0 0 4px 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.theme-description {
+  margin: 0 0 8px 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.theme-colors {
+  display: flex;
+  gap: 6px;
+}
+
+.color-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  cursor: help;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+/* Checkbox Grid */
+.checkbox-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+  padding: 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.checkbox-label input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--primary);
+}
+
+/* Responsive - Stack on mobile */
+@media (max-width: 480px) {
+  .theme-preview-card {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .theme-preview-swatch {
+    width: 100px;
+    height: 120px;
+  }
+
+  .theme-colors {
+    justify-content: center;
+  }
+
+  .checkbox-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Add theme dropdown with visual preview card to export modal
- Implement theme preview showing colors, name, and description
- Add localStorage persistence for user theme preference
- Add responsive CSS styles for theme selection UI

## Changes
- **admin.js**: Updated `showExportOptionsModal()` with theme dropdown and preview card component
- **admin.css**: Added styles for theme preview card, color dots, checkbox grid, and responsive layout

## Test Plan
- [ ] Open export options modal from admin panel
- [ ] Verify theme dropdown shows all 5 themes
- [ ] Select different themes and verify preview card updates
- [ ] Export with selected theme and verify output styling
- [ ] Refresh page and verify theme preference is restored
- [ ] Test responsive layout on mobile viewport

Closes #13