### PR TITLE
feat(portfolio): exporter IR unification and export fixes

### DIFF
--- a/portfolio/admin.html
+++ b/portfolio/admin.html
@@ -152,6 +152,7 @@
   <script src="admin/utils/preview-renderer.js?v=3.0.0"></script>
   <script src="admin/utils/section-order-manager.js?v=3.0.0"></script>
   <script src="admin/utils/export-content.js?v=3.0.0"></script>
+  <script src="admin/utils/export-ir.js?v=3.0.0"></script>
   <script src="admin/utils/pdf-exporter.js?v=3.0.0"></script>
   <script src="admin/utils/docx-exporter.js?v=3.0.0"></script>
   <script src="admin/components/form-fields.js?v=3.0.0"></script>

--- a/portfolio/admin.html
+++ b/portfolio/admin.html
@@ -15,8 +15,8 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="styles.css?v=3.0.0">
-  <link rel="stylesheet" href="admin/admin.css?v=3.0.0">
+  <link rel="stylesheet" href="styles.css?v=3.1.0">
+  <link rel="stylesheet" href="admin/admin.css?v=3.1.0">
 
 </head>
 <body>
@@ -136,8 +136,8 @@
   </div>
 
   <!-- Data (loaded from main portfolio) -->
-  <script src="data/data.js?v=3.0.0"></script>
-  <script src="utils/i18n.js?v=3.0.0"></script>
+  <script src="data/data.js?v=3.1.0"></script>
+  <script src="utils/i18n.js?v=3.1.0"></script>
 
   <!-- Export Libraries (vendored from npm: pdfmake 0.2.10, docx 8.5.0, file-saver 2.0.5) -->
   <!-- Must load before exporters -->
@@ -147,16 +147,16 @@
   <script src="admin/vendor/FileSaver.min.js"></script>
 
   <!-- Admin Scripts -->
-  <script src="admin/utils/theme-config.js?v=3.0.0"></script>
-  <script src="admin/utils/style-manager.js?v=3.0.0"></script>
-  <script src="admin/utils/preview-renderer.js?v=3.0.0"></script>
-  <script src="admin/utils/section-order-manager.js?v=3.0.0"></script>
-  <script src="admin/utils/export-content.js?v=3.0.0"></script>
-  <script src="admin/utils/export-ir.js?v=3.0.0"></script>
-  <script src="admin/utils/pdf-exporter.js?v=3.0.0"></script>
-  <script src="admin/utils/docx-exporter.js?v=3.0.0"></script>
-  <script src="admin/components/form-fields.js?v=3.0.0"></script>
-  <script src="admin/components/admin-components.js?v=3.0.0"></script>
-  <script src="admin/admin.js?v=3.0.0"></script>
+  <script src="admin/utils/theme-config.js?v=3.1.0"></script>
+  <script src="admin/utils/style-manager.js?v=3.1.0"></script>
+  <script src="admin/utils/preview-renderer.js?v=3.1.0"></script>
+  <script src="admin/utils/section-order-manager.js?v=3.1.0"></script>
+  <script src="admin/utils/export-content.js?v=3.1.0"></script>
+  <script src="admin/utils/export-ir.js?v=3.1.0"></script>
+  <script src="admin/utils/pdf-exporter.js?v=3.1.0"></script>
+  <script src="admin/utils/docx-exporter.js?v=3.1.0"></script>
+  <script src="admin/components/form-fields.js?v=3.1.0"></script>
+  <script src="admin/components/admin-components.js?v=3.1.0"></script>
+  <script src="admin/admin.js?v=3.1.0"></script>
 </body>
 </html>

--- a/portfolio/admin/admin.js
+++ b/portfolio/admin/admin.js
@@ -729,6 +729,9 @@ class AdminApp {
       });
 
       this.hideExportProgress();
+      if (result.fontWarning) {
+        this.showToast(result.fontWarning, 'warning');
+      }
       this.showToast(`PDF exported: ${result.filename}`, 'success');
     } catch (error) {
       this.hideExportProgress();

--- a/portfolio/admin/utils/docx-exporter.js
+++ b/portfolio/admin/utils/docx-exporter.js
@@ -2,7 +2,12 @@
  * DOCX Exporter - Generate Word documents from portfolio data using docx.js
  * Supports theme-based styling via StyleManager
  *
- * Dependencies: utils/export-content.js (shared labels, cover-page content)
+ * Content (sections, field order, labels, localized strings) comes from the
+ * format-neutral tree built by utils/export-ir.js (window.ExportIR); this
+ * file only maps IR nodes to docx.js constructs and owns every styling
+ * decision (colors, sizes, spacing, keep-together pagination).
+ *
+ * Dependencies: utils/export-content.js (labels), utils/export-ir.js (IR)
  */
 
 class DOCXExporter {
@@ -18,104 +23,6 @@ class DOCXExporter {
    */
   getLang() {
     return window.currentLanguage || window.getLanguage?.() || 'ko';
-  }
-
-  /**
-   * Get text from multilingual object { ko: "...", en: "..." }
-   * @param {*} obj - Multilingual object or string
-   * @returns {string} Text in current language
-   */
-  getText(obj) {
-    if (!obj) return '';
-    if (typeof obj === 'string') return obj;
-    const lang = this.currentLang;
-    return obj[lang] || obj.ko || obj.en || '';
-  }
-
-  /**
-   * Get array from multilingual object { ko: [...], en: [...] }
-   * @param {*} obj - Multilingual array object or array
-   * @returns {Array} Array in current language
-   */
-  getArray(obj) {
-    if (!obj) return [];
-    if (Array.isArray(obj)) return obj;
-    const lang = this.currentLang;
-    return obj[lang] || obj.ko || obj.en || [];
-  }
-
-  /**
-   * Calculate duration from period string
-   * @param {string|Object} period - Period string or multilingual object
-   * @returns {string|null} Formatted duration string
-   */
-  calculateDuration(period) {
-    const periodStr = this.getText(period);
-    if (!periodStr) return null;
-
-    // Parse period formats: "YYYY.MM - YYYY.MM", "YYYY - YYYY", "YYYY.MM - Present"
-    const parts = periodStr.split(' - ');
-    if (parts.length !== 2) return null;
-
-    const parseDate = (str) => {
-      str = str.trim();
-      // Remove any existing duration info like "(8개월)" or "(8 months)"
-      str = str.replace(/\s*\([^)]*\)\s*$/, '');
-      if (str.toLowerCase() === 'present' || str === '현재') {
-        return new Date();
-      }
-      const [year, month] = str.split('.');
-      return new Date(parseInt(year), month ? parseInt(month) - 1 : 0);
-    };
-
-    try {
-      const startDate = parseDate(parts[0]);
-      const endDate = parseDate(parts[1]);
-
-      const months = (endDate.getFullYear() - startDate.getFullYear()) * 12
-                   + (endDate.getMonth() - startDate.getMonth()) + 1;
-
-      if (months <= 0) return null;
-
-      const lang = this.currentLang;
-      if (months >= 12) {
-        const years = Math.floor(months / 12);
-        const remainingMonths = months % 12;
-        if (remainingMonths === 0) {
-          return lang === 'ko' ? `${years}년` : `${years} yr${years > 1 ? 's' : ''}`;
-        }
-        return lang === 'ko'
-          ? `${years}년 ${remainingMonths}개월`
-          : `${years} yr${years > 1 ? 's' : ''} ${remainingMonths} mo`;
-      }
-      return lang === 'ko' ? `${months}개월` : `${months} mo`;
-    } catch (e) {
-      return null;
-    }
-  }
-
-  /**
-   * Format period with duration
-   * @param {string|Object} period - Period string or multilingual object
-   * @returns {string} Period with duration appended
-   */
-  formatPeriodWithDuration(period) {
-    let periodStr = this.getText(period);
-    // Remove any existing duration info like "(8개월)", "(1년 2개월)", "(8 months)", "(1 yr 2 mo)"
-    periodStr = periodStr.replace(/\s*\([^)]*(?:개월|년|months?|yrs?|mo)[^)]*\)/gi, '').trim();
-    const duration = this.calculateDuration(period);
-    if (duration) {
-      return `${periodStr} (${duration})`;
-    }
-    return periodStr;
-  }
-
-  /**
-   * Get localized labels (delegates to the shared ExportContent dictionary)
-   * @returns {Object} Localized label strings
-   */
-  getLabels() {
-    return window.ExportContent.getLabels(this.currentLang);
   }
 
   /**
@@ -440,85 +347,28 @@ class DOCXExporter {
   }
 
   /**
-   * Build docx document
+   * Build docx document from the format-neutral IR tree
    */
   buildDocument(data, sections, info) {
+    const ir = window.ExportIR.build(data, {
+      sections,
+      title: info.title,
+      author: info.author,
+      includeCoverPage: info.includeCoverPage,
+      includeCoverLetter: info.includeCoverLetter,
+      coverLetterTemplate: info.coverLetterTemplate,
+      pageBreakBetweenSections: info.pageBreakBetweenSections,
+      personalInfoFields: info.personalInfoFields
+    }, this.currentLang);
+
     const children = [];
-    const {
-      includeCoverLetter = false,
-      coverLetterTemplate = null,
-      includeCoverPage = true,
-      pageBreakBetweenSections = true,
-      personalInfoFields = []
-    } = info;
+    ir.children.forEach(section => children.push(...this.renderSection(section)));
 
-    // Cover page (hero + stats infographic)
-    if (includeCoverPage) {
-      children.push(...this.buildCoverPage(info, data, { personalInfoFields }));
-    }
-
-    // Cover letter (if included)
-    if (includeCoverLetter && coverLetterTemplate) {
-      children.push(new docx.Paragraph({ children: [], pageBreakBefore: true }));
-      children.push(...this.buildCoverLetterPage(coverLetterTemplate));
-    }
-
-    // Inline header (only when no cover page)
-    if (!includeCoverPage) {
-      children.push(...this.buildHeader(info));
-    }
-
-    // Build each section. With cover page (or cover letter), every section
-    // header begins a new page; otherwise only break between sections.
-    const headPlaced = includeCoverPage || includeCoverLetter;
-    sections.forEach((section, index) => {
-      const addPageBreak = headPlaced
-        ? true
-        : (pageBreakBetweenSections && index > 0);
-
-      switch (section) {
-        case 'expertise':
-          if (data.expertise) {
-            children.push(...this.buildExpertiseSection(data.expertise, addPageBreak));
-          }
-          break;
-        case 'projects':
-          if (data.projects) {
-            children.push(...this.buildProjectsSection(data.projects, addPageBreak));
-          }
-          break;
-        case 'career':
-          if (data.career) {
-            children.push(...this.buildCareerSection(data.career, addPageBreak));
-          }
-          break;
-        case 'testimonials':
-          if (data.testimonials) {
-            children.push(...this.buildTestimonialsSection(data.testimonials, addPageBreak));
-          }
-          break;
-        case 'manager':
-          if (data.manager) {
-            children.push(...this.buildManagerSection(data.manager, addPageBreak));
-          }
-          break;
-        case 'education':
-          if (data.education) {
-            children.push(...this.buildEducationSection(data.education, addPageBreak));
-          }
-          break;
-        case 'compensation':
-          if (data.compensation) {
-            children.push(...this.buildCompensationSection(data.compensation, addPageBreak));
-          }
-          break;
-      }
-    });
-
+    const includeCoverPage = ir.includeCoverPage;
     const sectionConfig = {
       properties: includeCoverPage ? { titlePage: true } : {},
       footers: {
-        default: this.buildPageFooter(info)
+        default: this.buildPageFooter(ir)
       },
       children
     };
@@ -531,271 +381,1084 @@ class DOCXExporter {
     }
 
     return new docx.Document({
-      creator: info.author,
-      title: info.title,
+      creator: ir.author,
+      title: ir.title,
       description: 'Professional Portfolio Document',
       sections: [sectionConfig]
     });
   }
 
+  // ── IR walkers ──────────────────────────────────────────────────────────
+
   /**
-   * Build cover letter page for DOCX
-   * @param {Object} template - Cover letter template object
-   * @returns {Array} docx Paragraph array for cover letter
+   * Render one IR section to an array of docx elements
+   * @param {Object} section - IR section node
+   * @returns {Array} docx elements
    */
-  buildCoverLetterPage(template) {
-    const children = [];
-
-    // Greeting
-    children.push(new docx.Paragraph({
-      children: [new docx.TextRun({
-        text: this.getText(template.greeting),
-        size: this.toHalfPt(this.getTypography('fontSize.body'))
-      })],
-      spacing: { after: this.getSpacing('section.gap') * 20 }
-    }));
-
-    // Opening paragraph
-    const position = this.getText(template.targetRole);
-    const opening = this.getText(template.opening).replace('{position}', position);
-    children.push(new docx.Paragraph({
-      children: [new docx.TextRun({
-        text: opening,
-        size: this.toHalfPt(this.getTypography('fontSize.body'))
-      })],
-      alignment: docx.AlignmentType.JUSTIFIED,
-      spacing: { after: this.getSpacing('section.gap') * 20 }
-    }));
-
-    // Key points
-    const keyPoints = this.getArray(template.keyPoints);
-    keyPoints.forEach(point => {
-      const text = this.getText(point);
-      // Parse **bold** text
-      const parts = text.split(/\*\*(.+?)\*\*/g);
-      const runs = parts.map((part, index) => {
-        if (index % 2 === 1) {
-          // Odd indices are inside **...**
-          return new docx.TextRun({
-            text: part,
-            bold: true,
-            color: this.getColor('primary'),
-            size: this.toHalfPt(this.getTypography('fontSize.body'))
-          });
-        }
-        return new docx.TextRun({
-          text: part,
-          size: this.toHalfPt(this.getTypography('fontSize.body'))
-        });
-      });
-
-      children.push(new docx.Paragraph({
-        children: runs,
-        bullet: { level: 0 },
-        spacing: { after: this.getSpacing('list.itemGap') * 20 }
-      }));
-    });
-
-    // Add spacing after bullet list
-    children.push(new docx.Paragraph({
-      text: '',
-      spacing: { after: this.getSpacing('section.gap') * 10 }
-    }));
-
-    // Closing paragraph
-    children.push(new docx.Paragraph({
-      children: [new docx.TextRun({
-        text: this.getText(template.closing),
-        size: this.toHalfPt(this.getTypography('fontSize.body'))
-      })],
-      alignment: docx.AlignmentType.JUSTIFIED,
-      spacing: { after: this.getSpacing('section.gap') * 30 }
-    }));
-
-    // Signature
-    children.push(new docx.Paragraph({
-      children: [new docx.TextRun({
-        text: this.getText(template.signature),
-        size: this.toHalfPt(this.getTypography('fontSize.body'))
-      })],
-      spacing: { after: 0 }
-    }));
-
-    return children;
+  renderSection(section) {
+    const out = [];
+    // The cover letter starts on a fresh page via an explicit break
+    // paragraph (the section headings carry their own pageBreakBefore).
+    if (section.id === 'coverLetter' && section.pageBreakBefore) {
+      out.push(new docx.Paragraph({ children: [], pageBreakBefore: true }));
+    }
+    out.push(...this.renderNodes(section.children));
+    return out;
   }
 
   /**
-   * Build cover page paragraphs (hero + stats infographic).
-   * The caller is responsible for placing this at the start of the document
-   * and ensuring the next heading uses pageBreakBefore.
-   * @param {Object} info - Document info
-   * @param {Object} data - Portfolio data
-   * @returns {Array<docx.Paragraph|docx.Table>} children for the cover page
+   * Render a list of IR nodes
+   * @param {Array} nodes - IR nodes
+   * @returns {Array} docx elements
    */
-  buildCoverPage(info, data, opts = {}) {
-    const children = [];
-    const lang = this.currentLang;
-    const selectedFieldIds = Array.isArray(opts.personalInfoFields) ? opts.personalInfoFields : [];
-    const showPersonalInfo = selectedFieldIds.length > 0;
-    // Subtitle and summary come from the shared ExportContent module
-    // (profile data first, shared constants as fallback).
-    const subtitle = window.ExportContent.getCoverSubtitle(lang, data.profile);
-    const summaryLines = window.ExportContent.getCoverSummaryLines(lang, data.profile);
+  renderNodes(nodes) {
+    const out = [];
+    (nodes || []).forEach(node => out.push(...this.renderNode(node)));
+    return out;
+  }
 
-    // Top accent rule — short bold mark above the name (executive editorial style).
-    // Implemented as a 1-cell left-anchored table so the rule does not span full width.
-    children.push(new docx.Table({
-      rows: [new docx.TableRow({
-        children: [new docx.TableCell({
-          children: [new docx.Paragraph({ children: [new docx.TextRun({ text: '' })] })],
-          shading: { type: docx.ShadingType.CLEAR, fill: this.getColor('primary') },
-          width: { size: 1200, type: docx.WidthType.DXA },
-          margins: { top: 60, bottom: 60, left: 0, right: 0 },
+  /**
+   * Render a single IR node
+   * @param {Object} node - IR node
+   * @returns {Array} docx elements
+   */
+  renderNode(node) {
+    switch (node.type) {
+      case 'group': return this.renderGroup(node);
+      case 'heading': return this.renderHeading(node);
+      case 'paragraph': return this.renderParagraph(node);
+      case 'bulletList': return this.renderBulletList(node);
+      case 'keyValueList': return this.renderKeyValueList(node);
+      case 'badgeRow': return this.renderBadgeRow(node);
+      case 'table': return this.renderTable(node);
+      case 'statsRow': return this.renderStatsRow(node);
+      case 'spacer': return this.renderSpacer(node);
+      default: return [];
+    }
+  }
+
+  /**
+   * Render an IR group. DOCX has no unbreakable container, so groups mostly
+   * flatten; per-role trailing spacers keep blocks visually distinct.
+   */
+  renderGroup(node) {
+    switch (node.role) {
+      case 'careerEntry': {
+        // Legacy DOCX field order: the italic company context line sits
+        // between the company header and the role line. The IR canonical
+        // order is role-first (web order); reorder here to preserve the
+        // historical DOCX layout.
+        const kids = node.children.slice();
+        const roleIdx = kids.findIndex(k => k.role === 'careerRole');
+        const descIdx = kids.findIndex(k => k.role === 'careerCompanyDescription');
+        if (roleIdx !== -1 && descIdx !== -1 && descIdx > roleIdx) {
+          const [desc] = kids.splice(descIdx, 1);
+          kids.splice(roleIdx, 0, desc);
+        }
+        const out = this.renderNodes(kids);
+        out.push(new docx.Paragraph({ children: [], spacing: { after: 100 } }));
+        return out;
+      }
+      case 'project': {
+        // Trailing spacer keeps each project visually distinct without
+        // wasting too much page height.
+        const out = this.renderNodes(node.children);
+        out.push(new docx.Paragraph({ children: [], spacing: { after: 240 } }));
+        return out;
+      }
+      default:
+        return this.renderNodes(node.children);
+    }
+  }
+
+  /**
+   * Render an IR heading node
+   */
+  renderHeading(node) {
+    switch (node.role) {
+      case 'section':
+        return this.createHeading2(node.text, !!node.pageBreakBefore);
+      case 'subsection':
+        return [this.createHeading3(node.text, !!node.pageBreakBefore)];
+      case 'expertiseCategory':
+      case 'coreCapabilities':
+      case 'certifications':
+        return [this.createHeading3WithKeep(node.text, !!node.keepWithNext)];
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * Render an IR paragraph node (role decides the exact typography)
+   */
+  renderParagraph(node) {
+    const bodySize = this.toHalfPt(this.getTypography('fontSize.body'));
+    const smallSize = this.toHalfPt(this.getTypography('fontSize.small'));
+
+    switch (node.role) {
+      // ── Cover page ────────────────────────────────────────────────
+      case 'coverName':
+        // Name — 32pt per Microsoft Word resume guide (28–35pt range)
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            bold: true,
+            size: this.toHalfPt(32),
+            color: this.getColor('text.primary')
+          })],
+          spacing: { after: 140 }
+        })];
+
+      case 'coverSubtitle':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            bold: true,
+            size: this.toHalfPt(12),
+            color: this.getColor('primary'),
+            characterSpacing: 30
+          })],
+          spacing: { after: node.tight ? 160 : 360 }
+        })];
+
+      case 'coverPersonalInfo':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            size: this.toHalfPt(9.5),
+            color: this.getColor('text.secondary')
+          })],
+          spacing: { after: 280 }
+        })];
+
+      case 'coverSummary':
+        // Executive summary — one paragraph per line, tight leading
+        return node.lines.map((line, i) => new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: line,
+            size: this.toHalfPt(10.5),
+            color: this.getColor('text.secondary')
+          })],
+          spacing: {
+            after: i === node.lines.length - 1 ? 480 : 80,
+            line: 320
+          }
+        }));
+
+      case 'coverCertsLabel':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            bold: true,
+            size: this.toHalfPt(9),
+            color: this.getColor('text.muted')
+          })],
+          spacing: { before: 200, after: 80 }
+        })];
+
+      case 'coverCertsText':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            bold: true,
+            size: this.toHalfPt(11),
+            color: this.getColor('success')
+          })],
+          spacing: { after: 0 }
+        })];
+
+      case 'coverDate':
+        // PDF-only content: the DOCX cover carries no date line.
+        return [];
+
+      // ── Cover letter ──────────────────────────────────────────────
+      case 'clGreeting':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({ text: node.text, size: bodySize })],
+          spacing: { after: this.getSpacing('section.gap') * 20 }
+        })];
+
+      case 'clOpening':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({ text: node.text, size: bodySize })],
+          alignment: docx.AlignmentType.JUSTIFIED,
+          spacing: { after: this.getSpacing('section.gap') * 20 }
+        })];
+
+      case 'clClosing':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({ text: node.text, size: bodySize })],
+          alignment: docx.AlignmentType.JUSTIFIED,
+          spacing: { after: this.getSpacing('section.gap') * 30 }
+        })];
+
+      case 'clSignature':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({ text: node.text, size: bodySize })],
+          spacing: { after: 0 }
+        })];
+
+      // ── Inline header (no cover page) ─────────────────────────────
+      case 'inlineHeader': {
+        const titleRun = node.runs.find(r => r.role === 'title');
+        const dateRun = node.runs.find(r => r.role === 'date');
+        return [
+          new docx.Paragraph({
+            children: [new docx.TextRun({
+              text: titleRun ? titleRun.text : '',
+              bold: true,
+              size: this.toHalfPt(32),
+              color: this.getColor('text.primary')
+            })],
+            spacing: { after: 80 }
+          }),
+          new docx.Paragraph({
+            children: [new docx.TextRun({
+              text: dateRun ? dateRun.text : '',
+              size: this.toHalfPt(11),
+              color: this.getColor('text.muted')
+            })],
+            spacing: { after: 200 }
+          })
+        ];
+      }
+
+      // ── Projects ──────────────────────────────────────────────────
+      case 'projectTitle':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            bold: true,
+            size: this.toHalfPt(16),
+            color: this.getColor('primary')  // Primary color for titles
+          })],
+          spacing: { before: 280, after: 80, line: 320 },
+          keepLines: true,
+          keepNext: true
+        })];
+
+      case 'projectMeta': {
+        const company = node.runs.find(r => r.role === 'company');
+        const period = node.runs.find(r => r.role === 'period');
+        const metaParts = [];
+        if (company) {
+          metaParts.push(new docx.TextRun({
+            text: company.text,
+            size: this.toHalfPt(10),
+            color: this.getColor('text.secondary'),
+            bold: true
+          }));
+        }
+        if (period) {
+          if (company) {
+            metaParts.push(new docx.TextRun({
+              text: ' | ',
+              size: this.toHalfPt(10),
+              color: this.getColor('text.muted')
+            }));
+          }
+          metaParts.push(new docx.TextRun({
+            text: period.text,
+            size: this.toHalfPt(10),
+            color: this.getColor('accent'),  // Accent color for dates
+            italics: true
+          }));
+        }
+        return [new docx.Paragraph({
+          children: metaParts,
+          spacing: { after: 120 },
+          keepLines: true,
+          keepNext: true
+        })];
+      }
+
+      case 'projectDescription':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            size: this.toHalfPt(11),
+            color: this.getColor('text.secondary')
+          })],
+          spacing: { after: 160, line: 360 },
+          keepLines: true,
+          keepNext: true
+        })];
+
+      case 'blockLabel': {
+        // Color-coded '[ Label ]' block headers (web palette)
+        const styles = {
+          roles: { color: '3b82f6', fill: 'eff6ff', before: 40 },
+          challenges: { color: 'f59e0b', fill: 'fef3c7', before: 60 },
+          solutions: { color: '3b82f6', fill: 'dbeafe', before: 60 },
+          achievements: { color: '10b981', fill: 'd1fae5', before: 60 },
+          keyAchievements: { color: '10b981', fill: 'd1fae5', before: 60 }
+        };
+        const s = styles[node.variant] || styles.roles;
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            bold: true,
+            size: this.toHalfPt(14),
+            color: s.color,
+            shading: {
+              type: docx.ShadingType.CLEAR,
+              fill: s.fill
+            }
+          })],
+          spacing: { before: s.before, after: 40 },
+          keepLines: true,
+          keepNext: true
+        })];
+      }
+
+      // ── Career ────────────────────────────────────────────────────
+      case 'careerHeader': {
+        const companyRuns = [];
+        node.runs.forEach(r => {
+          if (r.role === 'title') {
+            companyRuns.push(new docx.TextRun({
+              text: r.text,
+              bold: true,
+              size: this.toHalfPt(15),
+              color: this.getColor('primary')  // Primary color for company
+            }));
+          } else if (r.role === 'badge') {
+            companyRuns.push(new docx.TextRun({
+              text: ' [' + r.text + ']',
+              bold: true,
+              size: this.toHalfPt(10),
+              color: 'f59e0b'  // Warning color
+            }));
+          } else if (r.role === 'period') {
+            companyRuns.push(new docx.TextRun({
+              text: `  ${r.text}`,
+              size: this.toHalfPt(10),
+              color: '3b82f6',  // Primary color for dates
+              bold: true
+            }));
+          }
+        });
+        return [new docx.Paragraph({
+          children: companyRuns,
+          spacing: { before: 150, after: 50 },
+          keepLines: true,
+          keepNext: true
+        })];
+      }
+
+      case 'careerCompanyDescription':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            size: bodySize,
+            italics: true,
+            color: this.getColor('text.muted')
+          })],
+          spacing: { after: this.getSpacing('list.itemSpacing') },
+          keepLines: true,
+          keepNext: true
+        })];
+
+      case 'careerRole':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: '> ' + node.text,
+            size: this.toHalfPt(12),
+            color: '0f172a',  // Text primary
+            bold: true
+          })],
+          spacing: { after: this.getSpacing('list.itemSpacing') },
+          keepLines: true,
+          keepNext: !!node.keepWithNext
+        })];
+
+      case 'careerResponsibilities': {
+        const label = node.runs.find(r => r.role === 'label');
+        const value = node.runs.find(r => r.role === 'value');
+        return [new docx.Paragraph({
+          children: [
+            new docx.TextRun({
+              text: `${label ? label.text : ''} `,
+              bold: true,
+              size: bodySize,
+              color: this.getColor('text.secondary')
+            }),
+            new docx.TextRun({
+              text: value ? value.text : '',
+              size: bodySize,
+              color: this.getColor('text.secondary')
+            })
+          ],
+          spacing: { after: this.getSpacing('list.itemSpacing') },
+          keepLines: true,
+          keepNext: !!node.keepWithNext
+        })];
+      }
+
+      case 'careerDescription':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            size: bodySize,
+            color: this.getColor('text.secondary')
+          })],
+          spacing: { after: this.getSpacing('list.itemSpacing') },
+          keepLines: true,
+          keepNext: !!node.keepWithNext
+        })];
+
+      case 'careerNote':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            size: smallSize,
+            italics: true,
+            color: this.getColor('text.muted')
+          })],
+          spacing: { after: this.getSpacing('list.itemSpacing') },
+          keepLines: true,
+          keepNext: !!node.keepWithNext
+        })];
+
+      case 'careerLeaveReason': {
+        const label = node.runs.find(r => r.role === 'label');
+        const value = node.runs.find(r => r.role === 'value');
+        return [new docx.Paragraph({
+          children: [
+            new docx.TextRun({
+              text: `${label ? label.text : ''} `,
+              bold: true,
+              size: smallSize,
+              color: this.getColor('text.muted')
+            }),
+            new docx.TextRun({
+              text: value ? value.text : '',
+              size: smallSize,
+              italics: true,
+              color: this.getColor('text.muted')
+            })
+          ],
+          spacing: { after: this.getSpacing('list.itemSpacing') },
+          keepLines: true,
+          keepNext: !!node.keepWithNext
+        })];
+      }
+
+      // ── Education ─────────────────────────────────────────────────
+      case 'eduHeader': {
+        const title = node.runs.find(r => r.role === 'title');
+        const meta = node.runs.find(r => r.role === 'meta');
+        return [new docx.Paragraph({
+          children: [
+            new docx.TextRun({
+              text: title ? title.text : '',
+              bold: true,
+              size: this.toHalfPt(this.getTypography('fontSize.h3')),
+              color: this.getColor('primary')
+            }),
+            new docx.TextRun({
+              text: '\t' + (meta ? meta.text : ''),
+              bold: true,
+              size: smallSize,
+              color: this.getColor('primary')
+            })
+          ],
+          tabStops: [{ type: docx.TabStopType.RIGHT, position: 9000 }],
+          spacing: { before: 120, after: 60 }
+        })];
+      }
+
+      case 'eduDegree':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            size: bodySize,
+            color: this.getColor('text.primary')
+          })],
+          spacing: { after: 40 }
+        })];
+
+      case 'eduLocation':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            italics: true,
+            size: smallSize,
+            color: this.getColor('text.muted')
+          })],
+          spacing: { after: 200 }
+        })];
+
+      // ── Compensation (private) ────────────────────────────────────
+      case 'compSubtitle':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            italics: true,
+            size: bodySize,
+            color: this.getColor('text.muted')
+          })],
+          spacing: { after: 80 }
+        })];
+
+      case 'compIntro':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            size: smallSize,
+            color: this.getColor('text.primary')
+          })],
+          spacing: { after: 120 }
+        })];
+
+      case 'compWarning':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            bold: true,
+            size: smallSize,
+            color: 'B91C1C'
+          })],
+          spacing: { after: 160 }
+        })];
+
+      case 'compBlockTitle':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            bold: true,
+            size: this.toHalfPt(this.getTypography('fontSize.h3')),
+            color: this.getColor('primary')
+          })],
+          spacing: { before: node.variant === 'package' ? 80 : 200, after: 60 }
+        })];
+
+      case 'compEstimate':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            italics: true,
+            size: smallSize,
+            color: this.getColor('text.muted')
+          })],
+          spacing: { after: 160 }
+        })];
+
+      case 'compStance':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            size: smallSize,
+            color: this.getColor('text.primary')
+          })],
+          spacing: { after: 120 }
+        })];
+
+      case 'compLastUpdated':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            italics: true,
+            size: smallSize,
+            color: this.getColor('text.muted')
+          })],
+          alignment: docx.AlignmentType.RIGHT,
+          spacing: { before: 120 }
+        })];
+
+      // ── Testimonials ──────────────────────────────────────────────
+      case 'testimonialFeaturedTag':
+        // PDF-only content: legacy DOCX renders no featured marker.
+        return [];
+
+      case 'testimonialQuote':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: `"${node.text}"`,
+            italics: true,
+            size: bodySize,
+            color: this.getColor('text.secondary')
+          })],
+          spacing: { before: 150, after: 80 },
+          indent: { left: this.getSpacing('list.indent'), right: this.getSpacing('list.indent') },
+          keepLines: true,
+          keepNext: true
+        })];
+
+      case 'testimonialAuthor': {
+        const authorRuns = [];
+        node.runs.forEach(r => {
+          if (r.role === 'author') {
+            authorRuns.push(new docx.TextRun({
+              text: '— ' + r.text,
+              bold: true,
+              size: smallSize,
+              color: this.getColor('text.primary')
+            }));
+          } else if (r.role === 'authorRole') {
+            authorRuns.push(new docx.TextRun({
+              text: `, ${r.text}`,
+              size: smallSize,
+              color: this.getColor('text.muted')
+            }));
+          } else if (r.role === 'relation') {
+            authorRuns.push(new docx.TextRun({
+              text: ` (${r.text})`,
+              size: smallSize,
+              color: this.getColor('text.muted')
+            }));
+          }
+        });
+        if (authorRuns.length === 0) return [];
+        return [new docx.Paragraph({
+          children: authorRuns,
+          spacing: { after: 80 },
+          indent: { left: this.getSpacing('list.indent') },
+          keepLines: true,
+          keepNext: !!node.keepWithNext
+        })];
+      }
+
+      // ── Manager / leadership ──────────────────────────────────────
+      case 'pmCapTitle':
+        return [new docx.Paragraph({
+          children: [
+            new docx.TextRun({ text: '◆  ', bold: true, size: this.toHalfPt(12), color: this.getColor('accent') }),
+            new docx.TextRun({ text: node.text, bold: true, size: this.toHalfPt(12), color: this.getColor('primary') })
+          ],
+          spacing: { before: node.first ? 0 : 180, after: 70 },
+          keepLines: true, keepNext: true
+        })];
+
+      case 'pmCapDescription':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: node.text,
+            italics: true, size: this.toHalfPt(10.5), color: this.getColor('text.secondary')
+          })],
+          spacing: { after: 100, line: 300 },
+          indent: { left: 240 },
+          keepLines: true, keepNext: true
+        })];
+
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * Render an IR bullet list (role decides marker, size and keep chain)
+   */
+  renderBulletList(node) {
+    const items = node.items || [];
+    const last = items.length - 1;
+
+    switch (node.role) {
+      case 'expertiseItems':
+        return items.map((item, index) => new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: item.text,
+            size: this.toHalfPt(this.getTypography('fontSize.body')),
+            color: this.getColor('text.secondary')
+          })],
+          spacing: { after: this.getSpacing('list.itemSpacing') },
+          indent: { left: this.getSpacing('list.indent') },
+          keepLines: true,
+          keepNext: index !== last || !!node.keepWithNext
+        }));
+
+      case 'projectDetail':
+      case 'careerAchievements':
+        return items.map((item, index) => new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: item.text,
+            size: this.toHalfPt(11),
+            color: this.getColor('text.secondary')
+          })],
+          spacing: { after: 50 },
+          indent: { left: this.getSpacing('list.indent') },
+          keepLines: true,
+          keepNext: index !== last || !!node.keepWithNext
+        }));
+
+      case 'pmCapHighlights':
+      case 'managerPrinciples':
+      case 'managerImpact': {
+        const markerColor = node.role === 'managerImpact'
+          ? this.getColor('success')
+          : this.getColor('accent');
+        return items.map(item => new docx.Paragraph({
+          children: [
+            new docx.TextRun({ text: '·  ', bold: true, color: markerColor, size: this.toHalfPt(10.5) }),
+            new docx.TextRun({ text: item.text, size: this.toHalfPt(10.5), color: this.getColor('text.secondary') })
+          ],
+          spacing: { after: 60, line: 300 },
+          indent: { left: 240 },
+          keepLines: true
+        }));
+      }
+
+      case 'clKeyPoints': {
+        const bodySize = this.toHalfPt(this.getTypography('fontSize.body'));
+        const out = items.map(item => new docx.Paragraph({
+          children: (item.runs || []).map(r => r.role === 'strong'
+            ? new docx.TextRun({
+              text: r.text,
+              bold: true,
+              color: this.getColor('primary'),
+              size: bodySize
+            })
+            : new docx.TextRun({ text: r.text, size: bodySize })),
+          bullet: { level: 0 },
+          spacing: { after: this.getSpacing('list.itemGap') * 20 }
+        }));
+        // Add spacing after bullet list
+        out.push(new docx.Paragraph({
+          text: '',
+          spacing: { after: this.getSpacing('section.gap') * 10 }
+        }));
+        return out;
+      }
+
+      case 'compNonNegotiables':
+        return items.map(item => new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: `• ${item.text}`,
+            size: this.toHalfPt(this.getTypography('fontSize.small')),
+            color: this.getColor('text.primary')
+          })],
+          spacing: { after: 30 }
+        }));
+
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * Render an IR key/value list
+   */
+  renderKeyValueList(node) {
+    const entries = node.entries || [];
+
+    switch (node.role) {
+      case 'heroCapabilities':
+        return entries.map((entry, index) => new docx.Paragraph({
+          children: [
+            new docx.TextRun({
+              text: `${entry.label}: `,
+              bold: true,
+              size: this.toHalfPt(this.getTypography('fontSize.body')),
+              color: this.getColor('text.primary')
+            }),
+            new docx.TextRun({
+              text: entry.value,
+              size: this.toHalfPt(this.getTypography('fontSize.body')),
+              color: this.getColor('text.secondary')
+            })
+          ],
+          spacing: { after: this.getSpacing('list.itemSpacing') },
+          indent: { left: this.getSpacing('list.indent') },
+          keepLines: true,
+          keepNext: index !== entries.length - 1
+        }));
+
+      case 'careerScale': {
+        const smallSize = this.toHalfPt(this.getTypography('fontSize.small'));
+        const scaleRuns = [];
+        entries.forEach((entry, index) => {
+          if (index > 0) {
+            scaleRuns.push(new docx.TextRun({
+              text: ' | ',
+              size: smallSize,
+              color: this.getColor('text.muted')
+            }));
+          }
+          scaleRuns.push(new docx.TextRun({
+            text: `${entry.label} `,
+            bold: true,
+            size: smallSize,
+            color: this.getColor('text.secondary')
+          }));
+          scaleRuns.push(new docx.TextRun({
+            text: entry.value,
+            size: smallSize,
+            color: this.getColor('text.secondary')
+          }));
+        });
+        return [new docx.Paragraph({
+          children: scaleRuns,
+          spacing: { after: this.getSpacing('list.itemSpacing') },
+          keepLines: true,
+          keepNext: !!node.keepWithNext
+        })];
+      }
+
+      case 'compComponents':
+        return entries.map(entry => new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: `• ${entry.label}: ${entry.value}`,
+            size: this.toHalfPt(this.getTypography('fontSize.small')),
+            color: this.getColor('text.primary')
+          })],
+          spacing: { after: 30 }
+        }));
+
+      case 'compRationales':
+        return entries.map(entry => new docx.Paragraph({
+          children: [
+            new docx.TextRun({
+              text: `${entry.label}: `,
+              bold: true,
+              size: this.toHalfPt(this.getTypography('fontSize.small')),
+              color: this.getColor('primary')
+            }),
+            new docx.TextRun({
+              text: entry.value,
+              size: this.toHalfPt(this.getTypography('fontSize.small')),
+              color: this.getColor('text.muted')
+            })
+          ],
+          spacing: { before: 60, after: 40 }
+        }));
+
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * Render an IR badge row. The joiner and decoration are DOCX styling
+   * decisions (the PDF walker uses its own).
+   */
+  renderBadgeRow(node) {
+    const items = node.items || [];
+
+    switch (node.role) {
+      case 'expertiseTags':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: items.join(' | '),
+            size: this.toHalfPt(this.getTypography('fontSize.small') + 1),  // Slightly larger
+            color: this.getColor('primary'),
+            bold: true,
+            shading: {
+              type: docx.ShadingType.CLEAR,
+              fill: 'dbeafe'  // Light blue background matching web accent-light
+            }
+          })],
+          spacing: { after: 100 },
+          indent: { left: this.getSpacing('list.indent') },
+          keepLines: true
+        })];
+
+      case 'certificationBadges':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: items.join(' | '),
+            bold: true,
+            size: this.toHalfPt(this.getTypography('fontSize.body') + 1),
+            color: this.getColor('success'),  // Success green matching web
+            shading: {
+              type: docx.ShadingType.CLEAR,
+              fill: 'd1fae5'  // Light green background
+            }
+          })],
+          spacing: { after: 150 },
+          indent: { left: this.getSpacing('list.indent') },
+          keepLines: true
+        })];
+
+      case 'projectTags':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: items.join(' • '),
+            size: this.toHalfPt(10),  // Slightly larger for readability
+            color: '3b82f6',  // Primary blue matching web
+            bold: true,
+            shading: {
+              type: docx.ShadingType.CLEAR,
+              fill: 'dbeafe'  // Light blue background matching web accent-light
+            }
+          })],
+          spacing: { after: 160 },
+          keepLines: true,
+          keepNext: node.keepWithNext ? true : false
+        })];
+
+      case 'careerTags':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: items.join(' | '),
+            size: this.toHalfPt(this.getTypography('fontSize.tiny')),
+            color: this.getColor('primary')
+          })],
+          keepLines: true,
+          spacing: { after: 80 }
+        })];
+
+      case 'testimonialLabels':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: items.join(' | '),
+            size: this.toHalfPt(this.getTypography('fontSize.tiny')),
+            color: this.getColor('primary')
+          })],
+          spacing: { after: 150 },
+          indent: { left: this.getSpacing('list.indent') },
+          keepLines: true
+        })];
+
+      case 'pmCapMetrics':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: items.join('   ·   '),
+            bold: true, size: this.toHalfPt(9), color: this.getColor('accent')
+          })],
+          spacing: { before: 60, after: 80 },
+          indent: { left: 240 }
+        })];
+
+      case 'pmCapTags':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({
+            text: items.join(' · '),
+            size: this.toHalfPt(9), color: this.getColor('text.muted')
+          })],
+          spacing: { after: 80 },
+          indent: { left: 240 }
+        })];
+
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * Render an IR table node
+   */
+  renderTable(node) {
+    switch (node.role) {
+      case 'compTiers': {
+        const smallSize = this.toHalfPt(this.getTypography('fontSize.small'));
+        const headerCells = (node.header || []).map(h => new docx.TableCell({
+          children: [new docx.Paragraph({
+            children: [new docx.TextRun({
+              text: h,
+              bold: true,
+              size: smallSize
+            })]
+          })]
+        }));
+
+        const rows = [new docx.TableRow({ children: headerCells, tableHeader: true })];
+        (node.rows || []).forEach(rowData => {
+          const cells = rowData.map((val, idx) => new docx.TableCell({
+            children: [new docx.Paragraph({
+              children: [new docx.TextRun({
+                text: val,
+                bold: idx === 0,
+                size: smallSize
+              })]
+            })]
+          }));
+          rows.push(new docx.TableRow({ children: cells }));
+        });
+
+        return [new docx.Table({
+          rows,
+          width: { size: 100, type: docx.WidthType.PERCENTAGE }
+        })];
+      }
+
+      case 'softSkillsGrid': {
+        // 2-column descriptive grid
+        const skills = node.cells || [];
+        const totalWidth = 9000;
+        const colWidth = Math.floor(totalWidth / 2);
+        const accentHex = this.getColor('accent');
+        const primaryHex = this.getColor('primary');
+        const secondaryHex = this.getColor('text.secondary');
+
+        const buildSkillCell = (skill) => new docx.TableCell({
+          children: [
+            new docx.Paragraph({
+              children: [
+                new docx.TextRun({ text: '◆  ', bold: true, size: this.toHalfPt(11), color: accentHex }),
+                new docx.TextRun({
+                  text: skill.title,
+                  bold: true, size: this.toHalfPt(11.5), color: primaryHex
+                })
+              ],
+              spacing: { after: 100 }
+            }),
+            ...(skill.description ? [new docx.Paragraph({
+              children: [new docx.TextRun({
+                text: skill.description,
+                size: this.toHalfPt(9.5), color: secondaryHex
+              })],
+              spacing: { after: 0, line: 280 },
+              indent: { left: 240 }
+            })] : [])
+          ],
+          width: { size: colWidth, type: docx.WidthType.DXA },
+          margins: { top: 120, bottom: 160, left: 180, right: 180 },
           borders: {
             top: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
             bottom: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
             left: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
             right: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' }
           }
-        })]
-      })],
-      width: { size: 1200, type: docx.WidthType.DXA },
-      borders: {
-        top: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-        bottom: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-        left: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-        right: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-        insideHorizontal: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-        insideVertical: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' }
-      }
-    }));
-    children.push(new docx.Paragraph({ children: [], spacing: { after: 600 } }));
+        });
 
-    // Name — 32pt per Microsoft Word resume guide (28–35pt range)
-    children.push(new docx.Paragraph({
-      children: [new docx.TextRun({
-        text: info.author || info.title,
-        bold: true,
-        size: this.toHalfPt(32),
-        color: this.getColor('text.primary')
-      })],
-      spacing: { after: 140 }
-    }));
+        const emptyCell = () => new docx.TableCell({
+          children: [new docx.Paragraph({ children: [new docx.TextRun({ text: '' })] })],
+          width: { size: colWidth, type: docx.WidthType.DXA },
+          borders: {
+            top: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+            bottom: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+            left: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+            right: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' }
+          }
+        });
 
-    // Subtitle / role line
-    children.push(new docx.Paragraph({
-      children: [new docx.TextRun({
-        text: subtitle,
-        bold: true,
-        size: this.toHalfPt(12),
-        color: this.getColor('primary'),
-        characterSpacing: 30
-      })],
-      spacing: { after: showPersonalInfo ? 160 : 360 }
-    }));
-
-    // Optional personal info row — only the field IDs the user selected.
-    if (showPersonalInfo && data.profile && Array.isArray(data.profile.fields)) {
-      const byId = new Map(data.profile.fields.map(f => [f.id, f]));
-      const parts = selectedFieldIds
-        .map(id => byId.get(id))
-        .filter(Boolean)
-        .map(f => this.getText(f.value))
-        .filter(v => v && v.length > 0);
-      if (parts.length) {
-        children.push(new docx.Paragraph({
-          children: [new docx.TextRun({
-            text: parts.join('   ·   '),
-            size: this.toHalfPt(9.5),
-            color: this.getColor('text.secondary')
-          })],
-          spacing: { after: 280 }
-        }));
-      }
-    }
-
-    // Executive summary — 3-line P&L / team-size / impact synthesis (HBS pattern)
-    summaryLines.forEach((line, i) => {
-      children.push(new docx.Paragraph({
-        children: [new docx.TextRun({
-          text: line,
-          size: this.toHalfPt(10.5),
-          color: this.getColor('text.secondary')
-        })],
-        spacing: {
-          after: i === summaryLines.length - 1 ? 480 : 80,
-          line: 320
+        const rows = [];
+        for (let i = 0; i < skills.length; i += 2) {
+          const rowCells = skills.slice(i, i + 2).map(buildSkillCell);
+          while (rowCells.length < 2) rowCells.push(emptyCell());
+          rows.push(new docx.TableRow({ children: rowCells }));
         }
-      }));
-    });
 
-    // Divider
-    children.push(new docx.Paragraph({
-      children: [new docx.TextRun({ text: '' })],
-      border: {
-        bottom: {
-          color: this.getColor('border'),
-          size: 6, space: 1, style: docx.BorderStyle.SINGLE
-        }
-      },
-      spacing: { after: 360 }
-    }));
+        return [
+          new docx.Table({
+            rows,
+            width: { size: totalWidth, type: docx.WidthType.DXA },
+            columnWidths: [colWidth, colWidth],
+            borders: {
+              top: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+              bottom: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+              left: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+              right: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+              insideHorizontal: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+              insideVertical: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' }
+            }
+          }),
+          new docx.Paragraph({ children: [], spacing: { after: 120 } })
+        ];
+      }
 
-    // Stats table infographic
-    const statsTable = this.buildStatsTable(data);
-    if (statsTable) {
-      children.push(statsTable);
-      children.push(new docx.Paragraph({ children: [], spacing: { after: 360 } }));
+      default:
+        return [];
     }
-
-    // Certifications row
-    if (data?.expertise?.certifications?.length > 0) {
-      const certText = data.expertise.certifications
-        .map(c => this.getText(c.name)).join('  ·  ');
-      children.push(new docx.Paragraph({
-        children: [new docx.TextRun({
-          text: lang === 'ko' ? '인증 / Certifications' : 'Certifications',
-          bold: true,
-          size: this.toHalfPt(9),
-          color: this.getColor('text.muted')
-        })],
-        spacing: { before: 200, after: 80 }
-      }));
-      children.push(new docx.Paragraph({
-        children: [new docx.TextRun({
-          text: certText,
-          bold: true,
-          size: this.toHalfPt(11),
-          color: this.getColor('success')
-        })],
-        spacing: { after: 0 }
-      }));
-    }
-
-    return children;
   }
 
   /**
-   * Build a 4-column stats infographic table for the cover page
-   * @param {Object} data - Portfolio data
-   * @returns {docx.Table|null} stats table or null when no data
+   * Render the cover-page stats row as a 2-row infographic table
    */
-  buildStatsTable(data) {
-    const lang = this.currentLang;
-    const kn = data?.manager?.businessImpact?.keyNumbers || {};
-    const certCount = data?.expertise?.certifications?.length || kn.certifications;
-    const stats = [];
-
-    stats.push({ value: '20+', label: lang === 'ko' ? '경력 (년)' : 'Years' });
-    if (certCount) stats.push({ value: String(certCount), label: lang === 'ko' ? '글로벌 인증' : 'Certifications' });
-    if (kn.ipos) stats.push({ value: String(kn.ipos), label: 'IPO' });
-    if (kn.performanceImprovement) stats.push({ value: String(kn.performanceImprovement), label: lang === 'ko' ? '성능 향상' : 'Performance' });
-    if (kn.projectsDelivered && stats.length < 4) {
-      stats.push({ value: String(kn.projectsDelivered), label: lang === 'ko' ? '프로젝트' : 'Projects' });
-    }
-
-    const finalStats = stats.slice(0, 4);
-    if (finalStats.length === 0) return null;
+  renderStatsRow(node) {
+    const finalStats = node.items || [];
+    if (finalStats.length === 0) return [];
 
     const totalWidth = 9000;
     const colWidth = Math.floor(totalWidth / finalStats.length);
@@ -830,22 +1493,131 @@ class DOCXExporter {
       width: { size: colWidth, type: docx.WidthType.DXA }
     }));
 
-    return new docx.Table({
-      rows: [
-        new docx.TableRow({ children: valueCells }),
-        new docx.TableRow({ children: labelCells })
-      ],
-      width: { size: totalWidth, type: docx.WidthType.DXA },
-      columnWidths: Array(finalStats.length).fill(colWidth),
-      borders: {
-        top: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-        bottom: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-        left: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-        right: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-        insideHorizontal: { style: docx.BorderStyle.SINGLE, size: 24, color: 'FFFFFF' },
-        insideVertical: { style: docx.BorderStyle.SINGLE, size: 24, color: 'FFFFFF' }
-      }
-    });
+    return [
+      new docx.Table({
+        rows: [
+          new docx.TableRow({ children: valueCells }),
+          new docx.TableRow({ children: labelCells })
+        ],
+        width: { size: totalWidth, type: docx.WidthType.DXA },
+        columnWidths: Array(finalStats.length).fill(colWidth),
+        borders: {
+          top: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+          bottom: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+          left: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+          right: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+          insideHorizontal: { style: docx.BorderStyle.SINGLE, size: 24, color: 'FFFFFF' },
+          insideVertical: { style: docx.BorderStyle.SINGLE, size: 24, color: 'FFFFFF' }
+        }
+      }),
+      new docx.Paragraph({ children: [], spacing: { after: 360 } })
+    ];
+  }
+
+  /**
+   * Render decorative spacers/rules (role decides the exact visual)
+   */
+  renderSpacer(node) {
+    switch (node.role) {
+      case 'coverTopRule':
+        // Top accent rule — short bold mark above the name (executive
+        // editorial style). Implemented as a 1-cell left-anchored table so
+        // the rule does not span full width.
+        return [
+          new docx.Table({
+            rows: [new docx.TableRow({
+              children: [new docx.TableCell({
+                children: [new docx.Paragraph({ children: [new docx.TextRun({ text: '' })] })],
+                shading: { type: docx.ShadingType.CLEAR, fill: this.getColor('primary') },
+                width: { size: 1200, type: docx.WidthType.DXA },
+                margins: { top: 60, bottom: 60, left: 0, right: 0 },
+                borders: {
+                  top: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+                  bottom: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+                  left: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+                  right: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' }
+                }
+              })]
+            })],
+            width: { size: 1200, type: docx.WidthType.DXA },
+            borders: {
+              top: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+              bottom: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+              left: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+              right: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+              insideHorizontal: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
+              insideVertical: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' }
+            }
+          }),
+          new docx.Paragraph({ children: [], spacing: { after: 600 } })
+        ];
+
+      case 'coverDivider':
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({ text: '' })],
+          border: {
+            bottom: {
+              color: this.getColor('border'),
+              size: 6, space: 1, style: docx.BorderStyle.SINGLE
+            }
+          },
+          spacing: { after: 360 }
+        })];
+
+      case 'inlineHeaderRule':
+        // Enhanced divider with primary color matching web design
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({ text: '' })],
+          border: {
+            bottom: {
+              color: this.getColor('primary'),
+              space: 1,
+              style: docx.BorderStyle.SINGLE,
+              size: 24  // Thicker border for web-like emphasis
+            }
+          },
+          spacing: { after: 400 }
+        })];
+
+      case 'projectDetailRule':
+        // Separator between project summary and expanded details
+        return [new docx.Paragraph({
+          children: [],
+          border: {
+            top: {
+              color: 'cbd5e1',  // Slightly darker border matching web border-hover
+              space: 1,
+              style: docx.BorderStyle.SINGLE,
+              size: 12  // Thicker for better visibility
+            }
+          },
+          spacing: { before: 80, after: 80 }
+        })];
+
+      case 'testimonialDivider':
+        // Thin centered rule between adjacent testimonials
+        return [new docx.Paragraph({
+          children: [new docx.TextRun({ text: '' })],
+          alignment: docx.AlignmentType.CENTER,
+          border: {
+            bottom: {
+              color: this.getColor('border'),
+              size: 4,
+              space: 1,
+              style: docx.BorderStyle.SINGLE
+            }
+          },
+          spacing: { before: 100, after: 140 },
+          indent: { left: 2400, right: 2400 }
+        })];
+
+      case 'pmCapabilitiesEnd':
+        // PDF-only trailing gap node.
+        return [];
+
+      default:
+        return [];
+    }
   }
 
   /**
@@ -896,1375 +1668,6 @@ class DOCXExporter {
         })
       ]
     });
-  }
-
-  /**
-   * Build document header with enhanced styling
-   */
-  buildHeader(info) {
-    const labels = this.getLabels();
-    const locale = this.currentLang === 'ko' ? 'ko-KR' : 'en-US';
-
-    return [
-      // Main title with gradient-like color
-      new docx.Paragraph({
-        children: [
-          new docx.TextRun({
-            text: info.author || info.title,
-            bold: true,
-            size: this.toHalfPt(32),
-            color: this.getColor('text.primary')
-          })
-        ],
-        spacing: { after: 80 }
-      }),
-      // Date
-      new docx.Paragraph({
-        children: [
-          new docx.TextRun({
-            text: new Date().toLocaleDateString(locale, {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric'
-            }),
-            size: this.toHalfPt(11),
-            color: this.getColor('text.muted')
-          })
-        ],
-        spacing: { after: 200 }
-      }),
-      // Enhanced divider with primary color matching web design
-      new docx.Paragraph({
-        children: [new docx.TextRun({ text: '' })],
-        border: {
-          bottom: {
-            color: this.getColor('primary'),
-            space: 1,
-            style: docx.BorderStyle.SINGLE,
-            size: 24  // Thicker border for web-like emphasis
-          }
-        },
-        spacing: { after: 400 }
-      })
-    ];
-  }
-
-  /**
-   * Build expertise section
-   * @param {Object} expertise - Expertise data
-   * @param {boolean} addPageBreak - Whether to add page break before section
-   */
-  buildExpertiseSection(expertise, addPageBreak = false) {
-    const children = [];
-    const labels = this.getLabels();
-
-    children.push(...this.createHeading2(labels.expertise, addPageBreak));
-
-    // Categories
-    if (expertise.categories && expertise.categories.length > 0) {
-      expertise.categories.forEach(category => {
-        const tags = this.getArray(category.tags);
-        const items = this.getArray(category.items);
-        const hasTags = tags.length > 0;
-        const hasItems = items.length > 0;
-
-        children.push(this.createHeading3WithKeep(this.getText(category.title) || 'Category', hasItems || hasTags));
-
-        if (hasItems) {
-          items.forEach((item, index) => {
-            const isLast = index === items.length - 1;
-            children.push(new docx.Paragraph({
-              children: [
-                new docx.TextRun({
-                  text: `${this.stripHtml(this.getText(item))}`,
-                  size: this.toHalfPt(this.getTypography('fontSize.body')),
-                  color: this.getColor('text.secondary')
-                })
-              ],
-              spacing: { after: this.getSpacing('list.itemSpacing') },
-              indent: { left: this.getSpacing('list.indent') },
-              keepLines: true,
-              keepNext: !isLast || hasTags
-            }));
-          });
-        }
-
-        // Handle tags for Technologies category with web-like styling
-        if (hasTags) {
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: tags.map(tag => this.getText(tag)).join(' | '),
-                size: this.toHalfPt(this.getTypography('fontSize.small') + 1),  // Slightly larger
-                color: this.getColor('primary'),
-                bold: true,
-                shading: {
-                  type: docx.ShadingType.CLEAR,
-                  fill: 'dbeafe'  // Light blue background matching web accent-light
-                }
-              })
-            ],
-            spacing: { after: 100 },
-            indent: { left: this.getSpacing('list.indent') },
-            keepLines: true
-          }));
-        }
-      });
-    }
-
-    // Hero Capabilities
-    if (expertise.heroCapabilities && expertise.heroCapabilities.length > 0) {
-      children.push(this.createHeading3WithKeep(labels.coreCapabilities, true));
-
-      expertise.heroCapabilities.forEach((cap, index) => {
-        const isLast = index === expertise.heroCapabilities.length - 1;
-        children.push(new docx.Paragraph({
-          children: [
-            new docx.TextRun({
-              text: `${this.getText(cap.title)}: `,
-              bold: true,
-              size: this.toHalfPt(this.getTypography('fontSize.body')),
-              color: this.getColor('text.primary')
-            }),
-            new docx.TextRun({
-              text: this.getText(cap.description),
-              size: this.toHalfPt(this.getTypography('fontSize.body')),
-              color: this.getColor('text.secondary')
-            })
-          ],
-          spacing: { after: this.getSpacing('list.itemSpacing') },
-          indent: { left: this.getSpacing('list.indent') },
-          keepLines: true,
-          keepNext: !isLast
-        }));
-      });
-    }
-
-    // Certifications with enhanced web-like styling
-    if (expertise.certifications && expertise.certifications.length > 0) {
-      children.push(this.createHeading3WithKeep(labels.certifications, true));
-
-      children.push(new docx.Paragraph({
-        children: [
-          new docx.TextRun({
-            text: expertise.certifications.map(cert => this.getText(cert.name)).join(' | '),
-            bold: true,
-            size: this.toHalfPt(this.getTypography('fontSize.body') + 1),
-            color: this.getColor('success'),  // Success green matching web
-            shading: {
-              type: docx.ShadingType.CLEAR,
-              fill: 'd1fae5'  // Light green background
-            }
-          })
-        ],
-        spacing: { after: 150 },
-        indent: { left: this.getSpacing('list.indent') },
-        keepLines: true
-      }));
-    }
-
-    return children;
-  }
-
-  /**
-   * Strip HTML tags from text
-   */
-  stripHtml(html) {
-    if (!html) return '';
-    return html.replace(/<[^>]*>/g, '');
-  }
-
-  /**
-   * Build projects section
-   * @param {Object} projects - Projects data
-   * @param {boolean} addPageBreak - Whether to add page break before section
-   */
-  buildProjectsSection(projects, addPageBreak = false) {
-    const children = [];
-    const labels = this.getLabels();
-
-    children.push(...this.createHeading2(labels.projects, addPageBreak));
-
-    // Each category that has projects starts on a new page for readability.
-    // The very first category sits on the same page as the PROJECTS header.
-    let firstCategory = true;
-
-    if (projects.featured && projects.featured.length > 0) {
-      children.push(this.createHeading3(labels.featuredProjects, !firstCategory));
-      firstCategory = false;
-      projects.featured.forEach(project => {
-        children.push(...this.formatProject(project));
-      });
-    }
-
-    const categories = ['medicalImaging', 'orthodontic', 'equipmentControl', 'enterprise', 'openSource'];
-    categories.forEach(category => {
-      if (projects[category] && projects[category].length > 0) {
-        const categoryName = this.formatCategoryName(category);
-        children.push(this.createHeading3(categoryName, !firstCategory));
-        firstCategory = false;
-        projects[category].forEach(project => {
-          children.push(...this.formatProject(project));
-        });
-      }
-    });
-
-    return children;
-  }
-
-  /**
-   * Format a single project
-   */
-  formatProject(project) {
-    const children = [];
-    const labels = this.getLabels();
-
-    // Title with primary color for emphasis
-    children.push(new docx.Paragraph({
-      children: [
-        new docx.TextRun({
-          text: this.getText(project.title) || this.getText(project.name) || 'Untitled Project',
-          bold: true,
-          size: this.toHalfPt(16),
-          color: this.getColor('primary')  // Primary color for titles
-        })
-      ],
-      spacing: { before: 280, after: 80, line: 320 },
-      keepLines: true,
-      keepNext: true
-    }));
-
-    // Company and period with distinct colors
-    if (project.company || project.period) {
-      const metaParts = [];
-      if (project.company) {
-        metaParts.push(new docx.TextRun({
-          text: this.getText(project.company),
-          size: this.toHalfPt(10),
-          color: this.getColor('text.secondary'),
-          bold: true
-        }));
-      }
-      if (project.period) {
-        if (project.company) {
-          metaParts.push(new docx.TextRun({
-            text: ' | ',
-            size: this.toHalfPt(10),
-            color: this.getColor('text.muted')
-          }));
-        }
-        metaParts.push(new docx.TextRun({
-          text: this.formatPeriodWithDuration(project.period),
-          size: this.toHalfPt(10),
-          color: this.getColor('accent'),  // Accent color for dates
-          italics: true
-        }));
-      }
-
-      children.push(new docx.Paragraph({
-        children: metaParts,
-        spacing: { after: 120 },
-        keepLines: true,
-        keepNext: true
-      }));
-    }
-
-    // Description with improved line height
-    if (project.description) {
-      children.push(new docx.Paragraph({
-        children: [
-          new docx.TextRun({
-            text: this.stripHtml(this.getText(project.description)),
-            size: this.toHalfPt(11),
-            color: this.getColor('text.secondary')
-          })
-        ],
-        spacing: { after: 160, line: 360 },
-        keepLines: true,
-        keepNext: true
-      }));
-    }
-
-    // Tags with enhanced web-like shading
-    const tags = this.getArray(project.tags);
-    if (tags.length > 0) {
-      children.push(new docx.Paragraph({
-        children: [
-          new docx.TextRun({
-            text: tags.map(tag => this.getText(tag)).join(' • '),
-            size: this.toHalfPt(10),  // Slightly larger for readability
-            color: '3b82f6',  // Primary blue matching web
-            bold: true,
-            shading: {
-              type: docx.ShadingType.CLEAR,
-              fill: 'dbeafe'  // Light blue background matching web accent-light
-            }
-          })
-        ],
-        spacing: { after: 160 },
-        keepLines: true,
-        keepNext: project.expanded ? true : false
-      }));
-    }
-
-    // Expanded details with color coding
-    if (project.expanded) {
-      const roles = this.getArray(project.expanded.roles);
-      if (roles.length > 0) {
-        // Add enhanced separator with web-like styling
-        children.push(new docx.Paragraph({
-          children: [],
-          border: {
-            top: {
-              color: 'cbd5e1',  // Slightly darker border matching web border-hover
-              space: 1,
-              style: docx.BorderStyle.SINGLE,
-              size: 12  // Thicker for better visibility
-            }
-          },
-          spacing: { before: 80, after: 80 }
-        }));
-
-        children.push(new docx.Paragraph({
-          children: [
-            new docx.TextRun({
-              text: '[ ' + labels.keyResponsibilities + ' ]',
-              bold: true,
-              size: this.toHalfPt(14),  // Slightly larger
-              color: '3b82f6',  // Primary blue matching web
-              shading: {
-                type: docx.ShadingType.CLEAR,
-                fill: 'eff6ff'  // Light blue background
-              }
-            })
-          ],
-          spacing: { before: 40, after: 40 },
-          keepLines: true,
-          keepNext: true
-        }));
-
-        const achievements = this.getArray(project.expanded.achievements);
-        roles.forEach((role, index) => {
-          const isLast = index === roles.length - 1;
-          const hasAchievements = achievements.length > 0;
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: `${this.stripHtml(this.getText(role))}`,
-                size: this.toHalfPt(11),
-                color: this.getColor('text.secondary')
-              })
-            ],
-            spacing: { after: 50 },
-            indent: { left: this.getSpacing('list.indent') },
-            keepLines: true,
-            keepNext: !isLast || hasAchievements
-          }));
-        });
-      }
-
-      // Challenges / solutions mirror the public site's expanded project
-      // card (components.js) so exported documents carry the same content.
-      const challenges = this.getArray(project.expanded.challenges);
-      if (challenges.length > 0) {
-        children.push(new docx.Paragraph({
-          children: [
-            new docx.TextRun({
-              text: '[ ' + labels.challenges + ' ]',
-              bold: true,
-              size: this.toHalfPt(14),  // Slightly larger
-              color: 'f59e0b',  // Warning amber matching web
-              shading: {
-                type: docx.ShadingType.CLEAR,
-                fill: 'fef3c7'  // Light amber background
-              }
-            })
-          ],
-          spacing: { before: 60, after: 40 },
-          keepLines: true,
-          keepNext: true
-        }));
-
-        challenges.forEach((challenge, index) => {
-          const isLast = index === challenges.length - 1;
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: `${this.stripHtml(this.getText(challenge))}`,
-                size: this.toHalfPt(11),
-                color: this.getColor('text.secondary')
-              })
-            ],
-            spacing: { after: 50 },
-            indent: { left: this.getSpacing('list.indent') },
-            keepLines: true,
-            keepNext: !isLast
-          }));
-        });
-      }
-
-      const solutions = this.getArray(project.expanded.solutions);
-      if (solutions.length > 0) {
-        children.push(new docx.Paragraph({
-          children: [
-            new docx.TextRun({
-              text: '[ ' + labels.solutions + ' ]',
-              bold: true,
-              size: this.toHalfPt(14),  // Slightly larger
-              color: '3b82f6',  // Primary blue matching web
-              shading: {
-                type: docx.ShadingType.CLEAR,
-                fill: 'dbeafe'  // Light blue background
-              }
-            })
-          ],
-          spacing: { before: 60, after: 40 },
-          keepLines: true,
-          keepNext: true
-        }));
-
-        solutions.forEach((solution, index) => {
-          const isLast = index === solutions.length - 1;
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: `${this.stripHtml(this.getText(solution))}`,
-                size: this.toHalfPt(11),
-                color: this.getColor('text.secondary')
-              })
-            ],
-            spacing: { after: 50 },
-            indent: { left: this.getSpacing('list.indent') },
-            keepLines: true,
-            keepNext: !isLast
-          }));
-        });
-      }
-
-      const achievements = this.getArray(project.expanded.achievements);
-      if (achievements.length > 0) {
-        children.push(new docx.Paragraph({
-          children: [
-            new docx.TextRun({
-              text: '[ ' + labels.achievements + ' ]',
-              bold: true,
-              size: this.toHalfPt(14),  // Slightly larger
-              color: '10b981',  // Success green matching web
-              shading: {
-                type: docx.ShadingType.CLEAR,
-                fill: 'd1fae5'  // Light green background
-              }
-            })
-          ],
-          spacing: { before: 60, after: 40 },
-          keepLines: true,
-          keepNext: true
-        }));
-
-        achievements.forEach((achievement, index) => {
-          const isLast = index === achievements.length - 1;
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: `${this.stripHtml(this.getText(achievement))}`,
-                size: this.toHalfPt(11),
-                color: this.getColor('text.secondary')
-              })
-            ],
-            spacing: { after: 50 },
-            indent: { left: this.getSpacing('list.indent') },
-            keepLines: true,
-            keepNext: !isLast
-          }));
-        });
-      }
-    }
-
-    // Trailing spacer keeps each project visually distinct without
-    // wasting too much page height.
-    children.push(new docx.Paragraph({ children: [], spacing: { after: 240 } }));
-
-    return children;
-  }
-
-  /**
-   * Build career section
-   * @param {Object} career - Career data
-   * @param {boolean} addPageBreak - Whether to add page break before section
-   */
-  buildCareerSection(career, addPageBreak = false) {
-    const children = [];
-    const labels = this.getLabels();
-
-    children.push(...this.createHeading2(labels.career, addPageBreak));
-
-    if (career.timeline && career.timeline.length > 0) {
-      career.timeline.forEach(item => {
-        // Determine what content exists for this item
-        const hasRole = item.role || item.position;
-        const hasCompanyDescription = item.companyDescription;
-        const hasResponsibilities = item.responsibilities;
-        const hasScale = item.scale && (item.scale.company || item.scale.team);
-        const hasLeaveReason = item.leaveReason;
-        const hasDescription = item.description;
-        const achievements = this.getArray(item.achievements);
-        const hasAchievements = achievements.length > 0;
-        const hasNote = item.note;
-        const tags = this.getArray(item.tags);
-        const hasTags = tags.length > 0;
-
-        // Company name with primary color and optional badge
-        const companyRuns = [
-          new docx.TextRun({
-            text: this.getText(item.company) || this.getText(item.title) || '',
-            bold: true,
-            size: this.toHalfPt(15),
-            color: this.getColor('primary')  // Primary color for company
-          })
-        ];
-
-        if (item.badge) {
-          companyRuns.push(new docx.TextRun({
-            text: ' [' + this.getText(item.badge) + ']',
-            bold: true,
-            size: this.toHalfPt(10),
-            color: 'f59e0b'  // Warning color
-          }));
-        }
-
-        companyRuns.push(new docx.TextRun({
-          text: `  ${this.formatPeriodWithDuration(item.period) || ''}`,
-          size: this.toHalfPt(10),
-          color: '3b82f6',  // Primary color for dates
-          bold: true
-        }));
-
-        children.push(new docx.Paragraph({
-          children: companyRuns,
-          spacing: { before: 150, after: 50 },
-          keepLines: true,
-          keepNext: true
-        }));
-
-        // Company description
-        if (hasCompanyDescription) {
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: this.stripHtml(this.getText(item.companyDescription)),
-                size: this.toHalfPt(this.getTypography('fontSize.body')),
-                italics: true,
-                color: this.getColor('text.muted')
-              })
-            ],
-            spacing: { after: this.getSpacing('list.itemSpacing') },
-            keepLines: true,
-            keepNext: true
-          }));
-        }
-
-        // Role with emphasis
-        if (hasRole) {
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: '> ' + (this.getText(item.role) || this.getText(item.position)),
-                size: this.toHalfPt(12),
-                color: '0f172a',  // Text primary
-                bold: true
-              })
-            ],
-            spacing: { after: this.getSpacing('list.itemSpacing') },
-            keepLines: true,
-            keepNext: hasResponsibilities || hasScale || hasDescription || hasAchievements || hasNote || hasTags || hasLeaveReason
-          }));
-        }
-
-        // Responsibilities
-        if (hasResponsibilities) {
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: `${labels.responsibilities} `,
-                bold: true,
-                size: this.toHalfPt(this.getTypography('fontSize.body')),
-                color: this.getColor('text.secondary')
-              }),
-              new docx.TextRun({
-                text: this.stripHtml(this.getText(item.responsibilities)),
-                size: this.toHalfPt(this.getTypography('fontSize.body')),
-                color: this.getColor('text.secondary')
-              })
-            ],
-            spacing: { after: this.getSpacing('list.itemSpacing') },
-            keepLines: true,
-            keepNext: hasScale || hasDescription || hasAchievements || hasNote || hasTags || hasLeaveReason
-          }));
-        }
-
-        // Scale (company/team size)
-        if (hasScale) {
-          const scaleRuns = [];
-          if (item.scale.company) {
-            scaleRuns.push(new docx.TextRun({
-              text: `${labels.companyScale} `,
-              bold: true,
-              size: this.toHalfPt(this.getTypography('fontSize.small')),
-              color: this.getColor('text.secondary')
-            }));
-            scaleRuns.push(new docx.TextRun({
-              text: this.getText(item.scale.company),
-              size: this.toHalfPt(this.getTypography('fontSize.small')),
-              color: this.getColor('text.secondary')
-            }));
-          }
-          if (item.scale.company && item.scale.team) {
-            scaleRuns.push(new docx.TextRun({
-              text: ' | ',
-              size: this.toHalfPt(this.getTypography('fontSize.small')),
-              color: this.getColor('text.muted')
-            }));
-          }
-          if (item.scale.team) {
-            scaleRuns.push(new docx.TextRun({
-              text: `${labels.teamScale} `,
-              bold: true,
-              size: this.toHalfPt(this.getTypography('fontSize.small')),
-              color: this.getColor('text.secondary')
-            }));
-            scaleRuns.push(new docx.TextRun({
-              text: this.getText(item.scale.team),
-              size: this.toHalfPt(this.getTypography('fontSize.small')),
-              color: this.getColor('text.secondary')
-            }));
-          }
-          children.push(new docx.Paragraph({
-            children: scaleRuns,
-            spacing: { after: this.getSpacing('list.itemSpacing') },
-            keepLines: true,
-            keepNext: hasDescription || hasAchievements || hasNote || hasTags || hasLeaveReason
-          }));
-        }
-
-        // Description
-        if (hasDescription) {
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: this.stripHtml(this.getText(item.description)),
-                size: this.toHalfPt(this.getTypography('fontSize.body')),
-                color: this.getColor('text.secondary')
-              })
-            ],
-            spacing: { after: this.getSpacing('list.itemSpacing') },
-            keepLines: true,
-            keepNext: hasAchievements || hasNote || hasTags || hasLeaveReason
-          }));
-        }
-
-        // Achievements with success color
-        if (hasAchievements) {
-          // Add achievements label with enhanced web-like styling
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: '[ ' + labels.keyAchievements + ' ]',
-                bold: true,
-                size: this.toHalfPt(14),  // Slightly larger
-                color: '10b981',  // Success green matching web
-                shading: {
-                  type: docx.ShadingType.CLEAR,
-                  fill: 'd1fae5'  // Light green background
-                }
-              })
-            ],
-            spacing: { before: 60, after: 40 },
-            keepLines: true,
-            keepNext: true
-          }));
-
-          achievements.forEach((achievement, index) => {
-            const isLast = index === achievements.length - 1;
-            children.push(new docx.Paragraph({
-              children: [
-                new docx.TextRun({
-                  text: `${this.stripHtml(this.getText(achievement))}`,
-                  size: this.toHalfPt(11),
-                  color: this.getColor('text.secondary')
-                })
-              ],
-              spacing: { after: 50 },
-              indent: { left: this.getSpacing('list.indent') },
-              keepLines: true,
-              keepNext: !isLast || hasNote || hasTags || hasLeaveReason
-            }));
-          });
-        }
-
-        // Note
-        if (hasNote) {
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: this.stripHtml(this.getText(item.note)),
-                size: this.toHalfPt(this.getTypography('fontSize.small')),
-                italics: true,
-                color: this.getColor('text.muted')
-              })
-            ],
-            spacing: { after: this.getSpacing('list.itemSpacing') },
-            keepLines: true,
-            keepNext: hasTags || hasLeaveReason
-          }));
-        }
-
-        // Leave reason
-        if (hasLeaveReason) {
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: `${labels.reasonForLeaving} `,
-                bold: true,
-                size: this.toHalfPt(this.getTypography('fontSize.small')),
-                color: this.getColor('text.muted')
-              }),
-              new docx.TextRun({
-                text: this.stripHtml(this.getText(item.leaveReason)),
-                size: this.toHalfPt(this.getTypography('fontSize.small')),
-                italics: true,
-                color: this.getColor('text.muted')
-              })
-            ],
-            spacing: { after: this.getSpacing('list.itemSpacing') },
-            keepLines: true,
-            keepNext: hasTags
-          }));
-        }
-
-        // Tags
-        if (hasTags) {
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: tags.map(tag => this.getText(tag)).join(' | '),
-                size: this.toHalfPt(this.getTypography('fontSize.tiny')),
-                color: this.getColor('primary')
-              })
-            ],
-            keepLines: true,
-            spacing: { after: 80 }
-          }));
-        }
-
-        children.push(new docx.Paragraph({ children: [], spacing: { after: 100 } }));
-      });
-    }
-
-    return children;
-  }
-
-  /**
-   * Build education section
-   * @param {Object} education - { items: [] }
-   * @param {boolean} addPageBreak
-   */
-  buildEducationSection(education, addPageBreak = false) {
-    const children = [];
-    const labels = this.getLabels();
-    children.push(...this.createHeading2(labels.education, addPageBreak));
-
-    const items = education?.items || [];
-    items.forEach(item => {
-      children.push(new docx.Paragraph({
-        children: [
-          new docx.TextRun({
-            text: this.getText(item.institution) || '',
-            bold: true,
-            size: this.toHalfPt(this.getTypography('fontSize.h3')),
-            color: this.getColor('primary')
-          }),
-          new docx.TextRun({
-            text: '\t' + (item.period || ''),
-            bold: true,
-            size: this.toHalfPt(this.getTypography('fontSize.small')),
-            color: this.getColor('primary')
-          })
-        ],
-        tabStops: [{ type: docx.TabStopType.RIGHT, position: 9000 }],
-        spacing: { before: 120, after: 60 }
-      }));
-
-      if (item.degree) {
-        children.push(new docx.Paragraph({
-          children: [new docx.TextRun({
-            text: this.getText(item.degree),
-            size: this.toHalfPt(this.getTypography('fontSize.body')),
-            color: this.getColor('text.primary')
-          })],
-          spacing: { after: 40 }
-        }));
-      }
-
-      if (item.location) {
-        children.push(new docx.Paragraph({
-          children: [new docx.TextRun({
-            text: this.getText(item.location),
-            italics: true,
-            size: this.toHalfPt(this.getTypography('fontSize.small')),
-            color: this.getColor('text.muted')
-          })],
-          spacing: { after: 200 }
-        }));
-      }
-    });
-
-    return children;
-  }
-
-  /**
-   * Build compensation section (PRIVATE).
-   * Renders the expected compensation tiers as a Word table. Only included
-   * when explicitly enabled via the export modal option.
-   * @param {Object} compensation - Compensation data
-   * @param {boolean} addPageBreak
-   */
-  buildCompensationSection(compensation, addPageBreak = false) {
-    const children = [];
-    const labels = this.getLabels();
-    children.push(...this.createHeading2(labels.compensation, addPageBreak));
-
-    if (compensation.subtitle) {
-      children.push(new docx.Paragraph({
-        children: [new docx.TextRun({
-          text: this.getText(compensation.subtitle),
-          italics: true,
-          size: this.toHalfPt(this.getTypography('fontSize.body')),
-          color: this.getColor('text.muted')
-        })],
-        spacing: { after: 80 }
-      }));
-    }
-    if (compensation.intro) {
-      children.push(new docx.Paragraph({
-        children: [new docx.TextRun({
-          text: this.getText(compensation.intro),
-          size: this.toHalfPt(this.getTypography('fontSize.small')),
-          color: this.getColor('text.primary')
-        })],
-        spacing: { after: 120 }
-      }));
-    }
-
-    children.push(new docx.Paragraph({
-      children: [new docx.TextRun({
-        text: this.getText({
-          ko: '※ 본 섹션은 비공개 협상용 자료입니다. 외부 유출 금지.',
-          en: '※ This section is private negotiation material. Do not distribute externally.'
-        }),
-        bold: true,
-        size: this.toHalfPt(this.getTypography('fontSize.small')),
-        color: 'B91C1C'
-      })],
-      spacing: { after: 160 }
-    }));
-
-    // Current package
-    if (compensation.currentPackage) {
-      children.push(new docx.Paragraph({
-        children: [new docx.TextRun({
-          text: this.getText(compensation.currentPackage.label) || '',
-          bold: true,
-          size: this.toHalfPt(this.getTypography('fontSize.h3')),
-          color: this.getColor('primary')
-        })],
-        spacing: { before: 80, after: 60 }
-      }));
-      (compensation.currentPackage.components || []).forEach(c => {
-        children.push(new docx.Paragraph({
-          children: [new docx.TextRun({
-            text: `• ${this.getText(c.label)}: ${c.value || ''}`,
-            size: this.toHalfPt(this.getTypography('fontSize.small')),
-            color: this.getColor('text.primary')
-          })],
-          spacing: { after: 30 }
-        }));
-      });
-      if (compensation.currentPackage.estimatedAnnualEv) {
-        children.push(new docx.Paragraph({
-          children: [new docx.TextRun({
-            text: this.getText(compensation.currentPackage.estimatedAnnualEv),
-            italics: true,
-            size: this.toHalfPt(this.getTypography('fontSize.small')),
-            color: this.getColor('text.muted')
-          })],
-          spacing: { after: 160 }
-        }));
-      }
-    }
-
-    // Tier table
-    const tiers = compensation.tiers || [];
-    if (tiers.length > 0) {
-      const headerCells = [
-        { ko: '시나리오', en: 'Tier' },
-        { ko: '기본급', en: 'Base' },
-        { ko: '사이닝', en: 'Signing' },
-        { ko: '인센티브', en: 'Incentive' },
-        { ko: '옵션/RSU', en: 'Options/RSU' },
-        { ko: '1년차 총보상', en: '1Y Total' }
-      ].map(h => new docx.TableCell({
-        children: [new docx.Paragraph({
-          children: [new docx.TextRun({
-            text: this.getText(h),
-            bold: true,
-            size: this.toHalfPt(this.getTypography('fontSize.small'))
-          })]
-        })]
-      }));
-
-      const rows = [new docx.TableRow({ children: headerCells, tableHeader: true })];
-      tiers.forEach(tier => {
-        const cellsData = [
-          tier.label, tier.base, tier.signing, tier.incentive, tier.options, tier.totalFirstYear
-        ];
-        const cells = cellsData.map((val, idx) => new docx.TableCell({
-          children: [new docx.Paragraph({
-            children: [new docx.TextRun({
-              text: this.getText(val) || '',
-              bold: idx === 0,
-              size: this.toHalfPt(this.getTypography('fontSize.small'))
-            })]
-          })]
-        }));
-        rows.push(new docx.TableRow({ children: cells }));
-      });
-
-      children.push(new docx.Table({
-        rows,
-        width: { size: 100, type: docx.WidthType.PERCENTAGE }
-      }));
-
-      // Rationales beneath the table
-      tiers.forEach(tier => {
-        if (tier.rationale) {
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({
-                text: `${this.getText(tier.label)}: `,
-                bold: true,
-                size: this.toHalfPt(this.getTypography('fontSize.small')),
-                color: this.getColor('primary')
-              }),
-              new docx.TextRun({
-                text: this.getText(tier.rationale),
-                size: this.toHalfPt(this.getTypography('fontSize.small')),
-                color: this.getColor('text.muted')
-              })
-            ],
-            spacing: { before: 60, after: 40 }
-          }));
-        }
-      });
-    }
-
-    // Non-negotiables
-    if (Array.isArray(compensation.nonNegotiables) && compensation.nonNegotiables.length) {
-      children.push(new docx.Paragraph({
-        children: [new docx.TextRun({
-          text: this.getText({ ko: '비협상 조건', en: 'Non-negotiable Terms' }),
-          bold: true,
-          size: this.toHalfPt(this.getTypography('fontSize.h3')),
-          color: this.getColor('primary')
-        })],
-        spacing: { before: 200, after: 60 }
-      }));
-      compensation.nonNegotiables.forEach(item => {
-        children.push(new docx.Paragraph({
-          children: [new docx.TextRun({
-            text: `• ${this.getText(item)}`,
-            size: this.toHalfPt(this.getTypography('fontSize.small')),
-            color: this.getColor('text.primary')
-          })],
-          spacing: { after: 30 }
-        }));
-      });
-    }
-
-    // Negotiation stance
-    if (compensation.negotiationStance) {
-      children.push(new docx.Paragraph({
-        children: [new docx.TextRun({
-          text: this.getText({ ko: '협상 입장', en: 'Negotiation Stance' }),
-          bold: true,
-          size: this.toHalfPt(this.getTypography('fontSize.h3')),
-          color: this.getColor('primary')
-        })],
-        spacing: { before: 200, after: 60 }
-      }));
-      children.push(new docx.Paragraph({
-        children: [new docx.TextRun({
-          text: this.getText(compensation.negotiationStance),
-          size: this.toHalfPt(this.getTypography('fontSize.small')),
-          color: this.getColor('text.primary')
-        })],
-        spacing: { after: 120 }
-      }));
-    }
-
-    if (compensation.lastUpdated) {
-      children.push(new docx.Paragraph({
-        children: [new docx.TextRun({
-          text: this.getText({
-            ko: `최종 갱신: ${compensation.lastUpdated}`,
-            en: `Last updated: ${compensation.lastUpdated}`
-          }),
-          italics: true,
-          size: this.toHalfPt(this.getTypography('fontSize.small')),
-          color: this.getColor('text.muted')
-        })],
-        alignment: docx.AlignmentType.RIGHT,
-        spacing: { before: 120 }
-      }));
-    }
-
-    return children;
-  }
-
-  /**
-   * Build testimonials section
-   * @param {Object} testimonials - Testimonials data
-   * @param {boolean} addPageBreak - Whether to add page break before section
-   */
-  buildTestimonialsSection(testimonials, addPageBreak = false) {
-    const children = [];
-    const labels = this.getLabels();
-
-    children.push(...this.createHeading2(labels.testimonials, addPageBreak));
-
-    // Build a flat list with a spacer + thin centered rule between
-    // adjacent testimonials so each block reads as its own card.
-    const ordered = [];
-    if (testimonials.featured) ordered.push({ t: testimonials.featured, featured: true });
-    if (testimonials.testimonials && testimonials.testimonials.length > 0) {
-      testimonials.testimonials.forEach(t => ordered.push({ t, featured: false }));
-    }
-
-    ordered.forEach(({ t, featured }, idx) => {
-      if (idx > 0) {
-        children.push(new docx.Paragraph({
-          children: [new docx.TextRun({ text: '' })],
-          alignment: docx.AlignmentType.CENTER,
-          border: {
-            bottom: {
-              color: this.getColor('border'),
-              size: 4,
-              space: 1,
-              style: docx.BorderStyle.SINGLE
-            }
-          },
-          spacing: { before: 100, after: 140 },
-          indent: { left: 2400, right: 2400 }
-        }));
-      }
-      children.push(...this.formatTestimonial(t, featured));
-    });
-
-    return children;
-  }
-
-  /**
-   * Format a single testimonial
-   */
-  formatTestimonial(testimonial, isFeatured) {
-    const children = [];
-    const hasLabels = testimonial.labels && testimonial.labels.length > 0;
-
-    // Quote
-    if (testimonial.quote || testimonial.text) {
-      const quoteText = this.getText(testimonial.quote) || this.getText(testimonial.text);
-      children.push(new docx.Paragraph({
-        children: [
-          new docx.TextRun({
-            text: `"${this.stripHtml(quoteText)}"`,
-            italics: true,
-            size: this.toHalfPt(this.getTypography('fontSize.body')),
-            color: this.getColor('text.secondary')
-          })
-        ],
-        spacing: { before: 150, after: 80 },
-        indent: { left: this.getSpacing('list.indent'), right: this.getSpacing('list.indent') },
-        keepLines: true,
-        keepNext: true
-      }));
-    }
-
-    // Author info
-    const authorRuns = [];
-    if (testimonial.author || testimonial.name) {
-      authorRuns.push(new docx.TextRun({
-        text: '— ' + (this.getText(testimonial.author) || this.getText(testimonial.name)),
-        bold: true,
-        size: this.toHalfPt(this.getTypography('fontSize.small')),
-        color: this.getColor('text.primary')
-      }));
-    }
-    if (testimonial.role) {
-      authorRuns.push(new docx.TextRun({
-        text: `, ${this.getText(testimonial.role)}`,
-        size: this.toHalfPt(this.getTypography('fontSize.small')),
-        color: this.getColor('text.muted')
-      }));
-    }
-    if (testimonial.relation) {
-      authorRuns.push(new docx.TextRun({
-        text: ` (${this.getText(testimonial.relation)})`,
-        size: this.toHalfPt(this.getTypography('fontSize.small')),
-        color: this.getColor('text.muted')
-      }));
-    }
-
-    if (authorRuns.length > 0) {
-      children.push(new docx.Paragraph({
-        children: authorRuns,
-        spacing: { after: 80 },
-        indent: { left: this.getSpacing('list.indent') },
-        keepLines: true,
-        keepNext: hasLabels
-      }));
-    }
-
-    // Labels
-    if (hasLabels) {
-      children.push(new docx.Paragraph({
-        children: [
-          new docx.TextRun({
-            text: testimonial.labels.map(l => this.getText(l.text)).join(' | '),
-            size: this.toHalfPt(this.getTypography('fontSize.tiny')),
-            color: this.getColor('primary')
-          })
-        ],
-        spacing: { after: 150 },
-        indent: { left: this.getSpacing('list.indent') },
-        keepLines: true
-      }));
-    }
-
-    return children;
-  }
-
-  /**
-   * Build manager/leadership section
-   * @param {Object} manager - Manager data
-   * @param {boolean} addPageBreak - Whether to add page break before section
-   */
-  buildManagerSection(manager, addPageBreak = false) {
-    const children = [];
-    const labels = this.getLabels();
-
-    children.push(...this.createHeading2(labels.manager, addPageBreak));
-
-    const lang = this.currentLang;
-    const accentHex = this.getColor('accent');
-    const primaryHex = this.getColor('primary');
-    const secondaryHex = this.getColor('text.secondary');
-    const mutedHex = this.getColor('text.muted');
-
-    // ── PM Capabilities — title + description + highlights + metrics ────
-    if (manager.pmCapabilities && manager.pmCapabilities.length > 0) {
-      children.push(this.createHeading3(labels.pmCapabilities, false));
-
-      manager.pmCapabilities.forEach((cap, idx) => {
-        children.push(new docx.Paragraph({
-          children: [
-            new docx.TextRun({ text: '◆  ', bold: true, size: this.toHalfPt(12), color: accentHex }),
-            new docx.TextRun({ text: this.getText(cap.title), bold: true, size: this.toHalfPt(12), color: primaryHex })
-          ],
-          spacing: { before: idx === 0 ? 0 : 180, after: 70 },
-          keepLines: true, keepNext: true
-        }));
-
-        if (cap.description) {
-          children.push(new docx.Paragraph({
-            children: [new docx.TextRun({
-              text: this.getText(cap.description),
-              italics: true, size: this.toHalfPt(10.5), color: secondaryHex
-            })],
-            spacing: { after: 100, line: 300 },
-            indent: { left: 240 },
-            keepLines: true, keepNext: true
-          }));
-        }
-
-        const highlights = this.getArray(cap.highlights);
-        highlights.forEach(h => {
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({ text: '·  ', bold: true, color: accentHex, size: this.toHalfPt(10.5) }),
-              new docx.TextRun({ text: this.stripHtml(this.getText(h)), size: this.toHalfPt(10.5), color: secondaryHex })
-            ],
-            spacing: { after: 60, line: 300 },
-            indent: { left: 240 },
-            keepLines: true
-          }));
-        });
-
-        const m = cap.metrics || {};
-        const chips = [];
-        if (Array.isArray(m.teamSizes) && m.teamSizes.length > 0) {
-          const min = Math.min(...m.teamSizes), max = Math.max(...m.teamSizes);
-          chips.push(`${lang === 'ko' ? '팀 규모' : 'Team Size'} ${min}–${max}`);
-        }
-        if (m.yearsLeading) chips.push(`${lang === 'ko' ? '리딩 연차' : 'Leading'} ${m.yearsLeading}+ ${lang === 'ko' ? '년' : 'yrs'}`);
-        if (m.projectsLed) chips.push(`${lang === 'ko' ? '리딩 프로젝트' : 'Projects Led'} ${m.projectsLed}+`);
-        if (m.onTimeDelivery) chips.push(`${lang === 'ko' ? '정시 납품' : 'On-Time'} ${m.onTimeDelivery}`);
-        if (m.certificationSuccess) chips.push(`${lang === 'ko' ? '인증 성공률' : 'Cert Success'} ${m.certificationSuccess}`);
-        if (m.majorProjects) chips.push(`${lang === 'ko' ? '주요 프로젝트' : 'Major Projects'} ${m.majorProjects}+`);
-
-        if (chips.length > 0) {
-          children.push(new docx.Paragraph({
-            children: [new docx.TextRun({
-              text: chips.join('   ·   '),
-              bold: true, size: this.toHalfPt(9), color: accentHex
-            })],
-            spacing: { before: 60, after: 80 },
-            indent: { left: 240 }
-          }));
-        }
-
-        const tags = this.getArray(cap.stakeholderTypes).concat(cap.frameworks || []);
-        if (tags.length > 0) {
-          children.push(new docx.Paragraph({
-            children: [new docx.TextRun({
-              text: tags.map(t => this.getText(t)).join(' · '),
-              size: this.toHalfPt(9), color: mutedHex
-            })],
-            spacing: { after: 80 },
-            indent: { left: 240 }
-          }));
-        }
-      });
-    }
-
-    // ── Leadership Style ───────────────────────────────────
-    if (manager.leadershipStyle) {
-      const principles = this.getArray(manager.leadershipStyle.principles);
-      if (principles.length > 0) {
-        children.push(this.createHeading3(labels.leadershipStyle, false));
-
-        principles.forEach(principle => {
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({ text: '·  ', bold: true, color: accentHex, size: this.toHalfPt(10.5) }),
-              new docx.TextRun({
-                text: this.stripHtml(this.getText(principle)),
-                size: this.toHalfPt(10.5), color: secondaryHex
-              })
-            ],
-            spacing: { after: 60, line: 300 },
-            indent: { left: 240 },
-            keepLines: true
-          }));
-        });
-      }
-    }
-
-    // ── Business Impact ────────────────────────────────────
-    // keyNumbers omitted — already shown on the cover-page stat infographic.
-    if (manager.businessImpact) {
-      const highlights = this.getArray(manager.businessImpact.highlights);
-      if (highlights.length > 0) {
-        children.push(this.createHeading3(labels.businessImpact, false));
-
-        highlights.forEach(h => {
-          children.push(new docx.Paragraph({
-            children: [
-              new docx.TextRun({ text: '·  ', bold: true, color: this.getColor('success'), size: this.toHalfPt(10.5) }),
-              new docx.TextRun({
-                text: this.stripHtml(this.getText(h)),
-                size: this.toHalfPt(10.5), color: secondaryHex
-              })
-            ],
-            spacing: { after: 60, line: 300 },
-            indent: { left: 240 },
-            keepLines: true
-          }));
-        });
-      }
-    }
-
-    // ── Soft Skills — 2-column descriptive grid ───────────
-    if (manager.softSkills && manager.softSkills.length > 0) {
-      children.push(this.createHeading3(labels.softSkills, false));
-
-      const totalWidth = 9000;
-      const colWidth = Math.floor(totalWidth / 2);
-
-      const buildSkillCell = (skill) => new docx.TableCell({
-        children: [
-          new docx.Paragraph({
-            children: [
-              new docx.TextRun({ text: '◆  ', bold: true, size: this.toHalfPt(11), color: accentHex }),
-              new docx.TextRun({
-                text: this.getText(skill.title),
-                bold: true, size: this.toHalfPt(11.5), color: primaryHex
-              })
-            ],
-            spacing: { after: 100 }
-          }),
-          ...(skill.description ? [new docx.Paragraph({
-            children: [new docx.TextRun({
-              text: this.getText(skill.description),
-              size: this.toHalfPt(9.5), color: secondaryHex
-            })],
-            spacing: { after: 0, line: 280 },
-            indent: { left: 240 }
-          })] : [])
-        ],
-        width: { size: colWidth, type: docx.WidthType.DXA },
-        margins: { top: 120, bottom: 160, left: 180, right: 180 },
-        borders: {
-          top: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-          bottom: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-          left: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-          right: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' }
-        }
-      });
-
-      const emptyCell = () => new docx.TableCell({
-        children: [new docx.Paragraph({ children: [new docx.TextRun({ text: '' })] })],
-        width: { size: colWidth, type: docx.WidthType.DXA },
-        borders: {
-          top: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-          bottom: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-          left: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-          right: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' }
-        }
-      });
-
-      const rows = [];
-      for (let i = 0; i < manager.softSkills.length; i += 2) {
-        const rowCells = manager.softSkills.slice(i, i + 2).map(buildSkillCell);
-        while (rowCells.length < 2) rowCells.push(emptyCell());
-        rows.push(new docx.TableRow({ children: rowCells }));
-      }
-
-      children.push(new docx.Table({
-        rows,
-        width: { size: totalWidth, type: docx.WidthType.DXA },
-        columnWidths: [colWidth, colWidth],
-        borders: {
-          top: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-          bottom: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-          left: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-          right: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-          insideHorizontal: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' },
-          insideVertical: { style: docx.BorderStyle.NONE, size: 0, color: 'FFFFFF' }
-        }
-      }));
-      children.push(new docx.Paragraph({ children: [], spacing: { after: 120 } }));
-    }
-
-    return children;
   }
 
   /**
@@ -2352,48 +1755,6 @@ class DOCXExporter {
       keepLines: true,
       keepNext
     });
-  }
-
-  /**
-   * Create table cell
-   */
-  createTableCell(text, isHeader = false) {
-    return new docx.TableCell({
-      children: [
-        new docx.Paragraph({
-          children: [
-            new docx.TextRun({
-              text: text || '',
-              bold: isHeader,
-              size: this.toHalfPt(this.getTypography('fontSize.small')),
-              color: isHeader ? this.getColor('text.primary') : this.getColor('text.secondary')
-            })
-          ]
-        })
-      ],
-      shading: isHeader ? { fill: this.getColor('background.table') } : undefined,
-      margins: {
-        top: 80,
-        bottom: 80,
-        left: 120,
-        right: 120
-      }
-    });
-  }
-
-  /**
-   * Format category name for display
-   */
-  formatCategoryName(category) {
-    const labels = this.getLabels();
-    const names = {
-      medicalImaging: labels.medicalImaging,
-      orthodontic: labels.orthodontic,
-      equipmentControl: labels.equipmentControl,
-      enterprise: labels.enterprise,
-      openSource: labels.openSource
-    };
-    return names[category] || category;
   }
 
   /**

--- a/portfolio/admin/utils/export-ir.js
+++ b/portfolio/admin/utils/export-ir.js
@@ -1,0 +1,841 @@
+/**
+ * Export IR - Format-neutral intermediate representation for exports.
+ *
+ * Single source of truth for export CONTENT decisions:
+ *   - which sections appear, in which order (cover page and cover letter
+ *     are sections too)
+ *   - which fields of each data record are emitted, in which order
+ *   - which labels are attached (delegated to window.ExportContent)
+ *   - localized inline strings (confidentiality notice, table headers, ...)
+ *
+ * The PDF and DOCX exporters consume this tree and only decide PRESENTATION:
+ * theme colors, typography, spacing, per-format decoration (joiners,
+ * brackets, bullet markers) and pagination primitives.
+ *
+ * Node vocabulary
+ * ---------------
+ *   document     { type, lang, title, author, includeCoverPage, children }
+ *   section      { type, id, pageBreakBefore, children }
+ *   group        { type, role, children, ... }        logical block (project,
+ *                careerEntry, testimonial, ...) a format may keep unbreakable
+ *   heading      { type, level: 2|3, role, text, pageBreakBefore?, keepWithNext? }
+ *   paragraph    { type, role, text? | runs? | lines?, keepWithNext?, ... }
+ *   bulletList   { type, role, variant?, items: [{text}|{runs}], keepWithNext? }
+ *   keyValueList { type, role, entries: [{label, value}], keepWithNext? }
+ *   badgeRow     { type, role, items: [string], keepWithNext? }   joiner is
+ *                format-side decoration
+ *   table        { type, role, header?, rows? | cells? }
+ *   statsRow     { type, items: [{value, label}] }
+ *   spacer       { type, role }                       decorative rule/gap
+ *
+ * Runs: [{ text, role? }] where run.role marks the semantic part
+ * ('label', 'value', 'strong', 'title', 'badge', 'period', ...).
+ *
+ * Known intentional per-format divergences (kept in the walkers, not here):
+ *   - coverDate / testimonialFeaturedTag / pmCapabilitiesEnd nodes are
+ *     rendered by the PDF walker only (legacy DOCX never rendered them).
+ *   - The DOCX walker renders careerCompanyDescription before careerRole
+ *     (legacy DOCX order); the IR canonical order is role first (web order).
+ *
+ * Classic script - exposes window.ExportIR. Depends on window.ExportContent.
+ */
+
+(function () {
+  'use strict';
+
+  // ── Shared helpers (content-level, format-agnostic) ─────────────────────
+
+  function getTextIn(obj, lang) {
+    return window.ExportContent.getTextIn(obj, lang);
+  }
+
+  function getArrayIn(obj, lang) {
+    return window.ExportContent.getArrayIn(obj, lang);
+  }
+
+  /** Strip HTML tags from text (same rule both exporters used) */
+  function stripHtml(html) {
+    if (!html) return '';
+    return html.replace(/<[^>]*>/g, '');
+  }
+
+  /**
+   * Format a period string with its computed duration appended.
+   * Removes any pre-existing duration suffix before recomputing.
+   */
+  function formatPeriodWithDuration(period, lang) {
+    let periodStr = getTextIn(period, lang);
+    periodStr = periodStr.replace(/\s*\([^)]*(?:개월|년|months?|yrs?|mo)[^)]*\)/gi, '').trim();
+    const duration = window.ExportContent.calculateDuration(period, lang);
+    return duration ? `${periodStr} (${duration})` : periodStr;
+  }
+
+  /** Parse **bold** markers into runs ({role:'strong'} for emphasized parts) */
+  function parseStrongRuns(text) {
+    const parts = String(text).split(/\*\*(.+?)\*\*/g);
+    return parts.map((part, index) =>
+      index % 2 === 1 ? { text: part, role: 'strong' } : { text: part });
+  }
+
+  function localizedDate(lang) {
+    const locale = lang === 'ko' ? 'ko-KR' : 'en-US';
+    return new Date().toLocaleDateString(locale, {
+      year: 'numeric', month: 'long', day: 'numeric'
+    });
+  }
+
+  // ── Cover page ──────────────────────────────────────────────────────────
+
+  /**
+   * Cover-page stats (max 4 entries). Was duplicated verbatim in both
+   * exporters (buildStatsTable / buildStatsInfographic).
+   */
+  function computeStats(data, lang) {
+    const kn = (data && data.manager && data.manager.businessImpact
+      && data.manager.businessImpact.keyNumbers) || {};
+    const certCount = (data && data.expertise && data.expertise.certifications
+      && data.expertise.certifications.length) || kn.certifications;
+    const stats = [];
+
+    stats.push({ value: '20+', label: lang === 'ko' ? '경력 (년)' : 'Years' });
+    if (certCount) stats.push({ value: String(certCount), label: lang === 'ko' ? '글로벌 인증' : 'Certifications' });
+    if (kn.ipos) stats.push({ value: String(kn.ipos), label: 'IPO' });
+    if (kn.performanceImprovement) stats.push({ value: String(kn.performanceImprovement), label: lang === 'ko' ? '성능 향상' : 'Performance' });
+    if (kn.projectsDelivered && stats.length < 4) {
+      stats.push({ value: String(kn.projectsDelivered), label: lang === 'ko' ? '프로젝트' : 'Projects' });
+    }
+    return stats.slice(0, 4);
+  }
+
+  function buildCoverSection(data, info, lang) {
+    const children = [];
+    const fieldIds = Array.isArray(info.personalInfoFields) ? info.personalInfoFields : [];
+    const showPersonalInfo = fieldIds.length > 0;
+    const subtitle = window.ExportContent.getCoverSubtitle(lang, data.profile);
+    const summaryLines = window.ExportContent.getCoverSummaryLines(lang, data.profile);
+
+    children.push({ type: 'spacer', role: 'coverTopRule' });
+    children.push({ type: 'paragraph', role: 'coverName', text: info.author || info.title });
+    // tight: personal-info row follows, so the subtitle keeps less bottom gap
+    children.push({ type: 'paragraph', role: 'coverSubtitle', text: subtitle, tight: showPersonalInfo });
+
+    if (showPersonalInfo && data.profile && Array.isArray(data.profile.fields)) {
+      const byId = new Map(data.profile.fields.map(f => [f.id, f]));
+      const parts = fieldIds
+        .map(id => byId.get(id))
+        .filter(Boolean)
+        .map(f => getTextIn(f.value, lang))
+        .filter(v => v && v.length > 0);
+      if (parts.length) {
+        children.push({ type: 'paragraph', role: 'coverPersonalInfo', text: parts.join('   ·   ') });
+      }
+    }
+
+    children.push({ type: 'paragraph', role: 'coverSummary', lines: summaryLines });
+    children.push({ type: 'spacer', role: 'coverDivider' });
+
+    const stats = computeStats(data, lang);
+    if (stats.length > 0) children.push({ type: 'statsRow', items: stats });
+
+    if (data && data.expertise && data.expertise.certifications
+      && data.expertise.certifications.length > 0) {
+      children.push({
+        type: 'paragraph', role: 'coverCertsLabel',
+        text: lang === 'ko' ? '인증 / Certifications' : 'Certifications'
+      });
+      children.push({
+        type: 'paragraph', role: 'coverCertsText',
+        text: data.expertise.certifications.map(c => getTextIn(c.name, lang)).join('  ·  ')
+      });
+    }
+
+    // Rendered by the PDF walker only (legacy DOCX cover carries no date).
+    children.push({ type: 'paragraph', role: 'coverDate', text: localizedDate(lang) });
+
+    return { type: 'section', id: 'cover', pageBreakBefore: false, children };
+  }
+
+  // ── Cover letter ────────────────────────────────────────────────────────
+
+  function buildCoverLetterSection(template, includeCoverPage, lang) {
+    const children = [];
+
+    children.push({ type: 'paragraph', role: 'clGreeting', text: getTextIn(template.greeting, lang) });
+
+    const position = getTextIn(template.targetRole, lang);
+    children.push({
+      type: 'paragraph', role: 'clOpening',
+      text: getTextIn(template.opening, lang).replace('{position}', position)
+    });
+
+    const keyPoints = getArrayIn(template.keyPoints, lang);
+    children.push({
+      type: 'bulletList', role: 'clKeyPoints',
+      items: keyPoints.map(p => ({ runs: parseStrongRuns(getTextIn(p, lang)) }))
+    });
+
+    children.push({ type: 'paragraph', role: 'clClosing', text: getTextIn(template.closing, lang) });
+    children.push({ type: 'paragraph', role: 'clSignature', text: getTextIn(template.signature, lang) });
+
+    return { type: 'section', id: 'coverLetter', pageBreakBefore: includeCoverPage, children };
+  }
+
+  // ── Inline header (no cover page) ───────────────────────────────────────
+
+  function buildInlineHeaderSection(info, lang) {
+    return {
+      type: 'section', id: 'inlineHeader', pageBreakBefore: false,
+      children: [
+        {
+          type: 'paragraph', role: 'inlineHeader',
+          runs: [
+            { text: info.author || info.title, role: 'title' },
+            { text: localizedDate(lang), role: 'date' }
+          ]
+        },
+        { type: 'spacer', role: 'inlineHeaderRule' }
+      ]
+    };
+  }
+
+  // ── Expertise ───────────────────────────────────────────────────────────
+
+  function buildExpertiseSection(expertise, labels, lang) {
+    const children = [{ type: 'heading', level: 2, role: 'section', text: labels.expertise }];
+
+    if (expertise.categories && expertise.categories.length > 0) {
+      expertise.categories.forEach(category => {
+        const items = getArrayIn(category.items, lang);
+        const tags = getArrayIn(category.tags, lang);
+        const g = { type: 'group', role: 'expertiseCategory', children: [] };
+
+        g.children.push({
+          type: 'heading', level: 3, role: 'expertiseCategory',
+          text: getTextIn(category.title, lang) || 'Category',
+          keepWithNext: items.length > 0 || tags.length > 0
+        });
+        if (items.length > 0) {
+          g.children.push({
+            type: 'bulletList', role: 'expertiseItems',
+            items: items.map(item => ({ text: stripHtml(getTextIn(item, lang)) })),
+            keepWithNext: tags.length > 0
+          });
+        }
+        if (tags.length > 0) {
+          g.children.push({
+            type: 'badgeRow', role: 'expertiseTags',
+            items: tags.map(tag => getTextIn(tag, lang))
+          });
+        }
+        children.push(g);
+      });
+    }
+
+    if (expertise.heroCapabilities && expertise.heroCapabilities.length > 0) {
+      children.push({
+        type: 'group', role: 'heroCapabilities',
+        children: [
+          { type: 'heading', level: 3, role: 'coreCapabilities', text: labels.coreCapabilities, keepWithNext: true },
+          {
+            type: 'keyValueList', role: 'heroCapabilities',
+            entries: expertise.heroCapabilities.map(cap => ({
+              label: getTextIn(cap.title, lang),
+              value: getTextIn(cap.description, lang)
+            }))
+          }
+        ]
+      });
+    }
+
+    if (expertise.certifications && expertise.certifications.length > 0) {
+      children.push({
+        type: 'group', role: 'certifications',
+        children: [
+          { type: 'heading', level: 3, role: 'certifications', text: labels.certifications, keepWithNext: true },
+          {
+            type: 'badgeRow', role: 'certificationBadges',
+            items: expertise.certifications.map(cert => getTextIn(cert.name, lang))
+          }
+        ]
+      });
+    }
+
+    return { type: 'section', id: 'expertise', children };
+  }
+
+  // ── Projects ────────────────────────────────────────────────────────────
+
+  const PROJECT_CATEGORY_ORDER = ['medicalImaging', 'orthodontic', 'equipmentControl', 'enterprise', 'openSource'];
+
+  function projectCategoryLabel(category, labels) {
+    const names = {
+      medicalImaging: labels.medicalImaging,
+      orthodontic: labels.orthodontic,
+      equipmentControl: labels.equipmentControl,
+      enterprise: labels.enterprise,
+      openSource: labels.openSource
+    };
+    return names[category] || category;
+  }
+
+  function buildProjectGroup(project, labels, lang) {
+    const children = [];
+
+    children.push({
+      type: 'paragraph', role: 'projectTitle',
+      text: getTextIn(project.title, lang) || getTextIn(project.name, lang) || 'Untitled Project'
+    });
+
+    if (project.company || project.period) {
+      const runs = [];
+      if (project.company) runs.push({ text: getTextIn(project.company, lang), role: 'company' });
+      if (project.period) runs.push({ text: formatPeriodWithDuration(project.period, lang), role: 'period' });
+      children.push({ type: 'paragraph', role: 'projectMeta', runs });
+    }
+
+    if (project.description) {
+      children.push({
+        type: 'paragraph', role: 'projectDescription',
+        text: stripHtml(getTextIn(project.description, lang))
+      });
+    }
+
+    const tags = getArrayIn(project.tags, lang);
+    if (tags.length > 0) {
+      children.push({
+        type: 'badgeRow', role: 'projectTags',
+        items: tags.map(tag => getTextIn(tag, lang)),
+        keepWithNext: !!project.expanded
+      });
+    }
+
+    if (project.expanded) {
+      const roles = getArrayIn(project.expanded.roles, lang);
+      const challenges = getArrayIn(project.expanded.challenges, lang);
+      const solutions = getArrayIn(project.expanded.solutions, lang);
+      const achievements = getArrayIn(project.expanded.achievements, lang);
+
+      const pushBlock = (variant, labelText, list, keepWithNext) => {
+        children.push({ type: 'paragraph', role: 'blockLabel', variant, text: '[ ' + labelText + ' ]' });
+        children.push({
+          type: 'bulletList', role: 'projectDetail', variant,
+          items: list.map(x => ({ text: stripHtml(getTextIn(x, lang)) })),
+          keepWithNext
+        });
+      };
+
+      if (roles.length > 0) {
+        children.push({ type: 'spacer', role: 'projectDetailRule' });
+        pushBlock('roles', labels.keyResponsibilities, roles, achievements.length > 0);
+      }
+      if (challenges.length > 0) pushBlock('challenges', labels.challenges, challenges, false);
+      if (solutions.length > 0) pushBlock('solutions', labels.solutions, solutions, false);
+      if (achievements.length > 0) pushBlock('achievements', labels.achievements, achievements, false);
+    }
+
+    return { type: 'group', role: 'project', children };
+  }
+
+  function buildProjectsSection(projects, labels, lang) {
+    const children = [{ type: 'heading', level: 2, role: 'section', text: labels.projects }];
+
+    // Each category after the first starts on a new page; the first category
+    // stays on the same page as the PROJECTS section header.
+    let firstCategory = true;
+    const pushCategory = (headingText, list) => {
+      children.push({
+        type: 'heading', level: 3, role: 'subsection',
+        text: headingText, pageBreakBefore: !firstCategory
+      });
+      firstCategory = false;
+      list.forEach(project => children.push(buildProjectGroup(project, labels, lang)));
+    };
+
+    if (projects.featured && projects.featured.length > 0) {
+      pushCategory(labels.featuredProjects, projects.featured);
+    }
+    PROJECT_CATEGORY_ORDER.forEach(category => {
+      if (projects[category] && projects[category].length > 0) {
+        pushCategory(projectCategoryLabel(category, labels), projects[category]);
+      }
+    });
+
+    return { type: 'section', id: 'projects', children };
+  }
+
+  // ── Career ──────────────────────────────────────────────────────────────
+
+  function buildCareerEntry(item, labels, lang) {
+    const children = [];
+
+    const achievements = getArrayIn(item.achievements, lang);
+    const tags = getArrayIn(item.tags, lang);
+    const hasRole = !!(item.role || item.position);
+    const hasCompanyDescription = !!item.companyDescription;
+    const hasResponsibilities = !!item.responsibilities;
+    const hasScale = !!(item.scale && (item.scale.company || item.scale.team));
+    const hasDescription = !!item.description;
+    const hasAchievements = achievements.length > 0;
+    const hasNote = !!item.note;
+    const hasLeaveReason = !!item.leaveReason;
+    const hasTags = tags.length > 0;
+
+    // Header: company (+ optional badge) + period
+    const headerRuns = [{ text: getTextIn(item.company, lang) || getTextIn(item.title, lang) || '', role: 'title' }];
+    if (item.badge) headerRuns.push({ text: getTextIn(item.badge, lang), role: 'badge' });
+    headerRuns.push({ text: formatPeriodWithDuration(item.period, lang) || '', role: 'period' });
+    children.push({ type: 'paragraph', role: 'careerHeader', runs: headerRuns, keepWithNext: true });
+
+    // Canonical order: role first, company context second (web order).
+    // The DOCX walker renders companyDescription before role (legacy order).
+    if (hasRole) {
+      children.push({
+        type: 'paragraph', role: 'careerRole',
+        text: getTextIn(item.role, lang) || getTextIn(item.position, lang),
+        keepWithNext: hasResponsibilities || hasScale || hasDescription
+          || hasAchievements || hasNote || hasTags || hasLeaveReason
+      });
+    }
+    if (hasCompanyDescription) {
+      children.push({
+        type: 'paragraph', role: 'careerCompanyDescription',
+        text: stripHtml(getTextIn(item.companyDescription, lang)),
+        keepWithNext: true
+      });
+    }
+    if (hasResponsibilities) {
+      children.push({
+        type: 'paragraph', role: 'careerResponsibilities',
+        runs: [
+          { text: labels.responsibilities, role: 'label' },
+          { text: stripHtml(getTextIn(item.responsibilities, lang)), role: 'value' }
+        ],
+        keepWithNext: hasScale || hasDescription || hasAchievements
+          || hasNote || hasTags || hasLeaveReason
+      });
+    }
+    if (hasScale) {
+      const entries = [];
+      if (item.scale.company) entries.push({ label: labels.companyScale, value: getTextIn(item.scale.company, lang) });
+      if (item.scale.team) entries.push({ label: labels.teamScale, value: getTextIn(item.scale.team, lang) });
+      children.push({
+        type: 'keyValueList', role: 'careerScale', entries,
+        keepWithNext: hasDescription || hasAchievements || hasNote || hasTags || hasLeaveReason
+      });
+    }
+    if (hasDescription) {
+      children.push({
+        type: 'paragraph', role: 'careerDescription',
+        text: stripHtml(getTextIn(item.description, lang)),
+        keepWithNext: hasAchievements || hasNote || hasTags || hasLeaveReason
+      });
+    }
+    if (hasAchievements) {
+      children.push({ type: 'paragraph', role: 'blockLabel', variant: 'keyAchievements', text: '[ ' + labels.keyAchievements + ' ]' });
+      children.push({
+        type: 'bulletList', role: 'careerAchievements',
+        items: achievements.map(a => ({ text: stripHtml(getTextIn(a, lang)) })),
+        keepWithNext: hasNote || hasTags || hasLeaveReason
+      });
+    }
+    if (hasNote) {
+      children.push({
+        type: 'paragraph', role: 'careerNote',
+        text: stripHtml(getTextIn(item.note, lang)),
+        keepWithNext: hasTags || hasLeaveReason
+      });
+    }
+    if (hasLeaveReason) {
+      children.push({
+        type: 'paragraph', role: 'careerLeaveReason',
+        runs: [
+          { text: labels.reasonForLeaving, role: 'label' },
+          { text: stripHtml(getTextIn(item.leaveReason, lang)), role: 'value' }
+        ],
+        keepWithNext: hasTags
+      });
+    }
+    if (hasTags) {
+      children.push({
+        type: 'badgeRow', role: 'careerTags',
+        items: tags.map(tag => getTextIn(tag, lang))
+      });
+    }
+
+    return { type: 'group', role: 'careerEntry', children };
+  }
+
+  function buildCareerSection(career, labels, lang) {
+    const children = [{ type: 'heading', level: 2, role: 'section', text: labels.career }];
+    if (career.timeline && career.timeline.length > 0) {
+      career.timeline.forEach(item => children.push(buildCareerEntry(item, labels, lang)));
+    }
+    return { type: 'section', id: 'career', children };
+  }
+
+  // ── Education ───────────────────────────────────────────────────────────
+
+  function buildEducationSection(education, labels, lang) {
+    const children = [{ type: 'heading', level: 2, role: 'section', text: labels.education }];
+    const items = (education && education.items) || [];
+
+    items.forEach(item => {
+      const g = { type: 'group', role: 'educationEntry', children: [] };
+      g.children.push({
+        type: 'paragraph', role: 'eduHeader',
+        runs: [
+          { text: getTextIn(item.institution, lang) || '', role: 'title' },
+          { text: item.period || '', role: 'meta' }
+        ]
+      });
+      if (item.degree) {
+        g.children.push({ type: 'paragraph', role: 'eduDegree', text: getTextIn(item.degree, lang) });
+      }
+      if (item.location) {
+        g.children.push({ type: 'paragraph', role: 'eduLocation', text: getTextIn(item.location, lang) });
+      }
+      children.push(g);
+    });
+
+    return { type: 'section', id: 'education', children };
+  }
+
+  // ── Compensation (private) ──────────────────────────────────────────────
+
+  function buildCompensationSection(compensation, labels, lang) {
+    const children = [{ type: 'heading', level: 2, role: 'section', text: labels.compensation }];
+
+    if (compensation.subtitle) {
+      children.push({ type: 'paragraph', role: 'compSubtitle', text: getTextIn(compensation.subtitle, lang) });
+    }
+    if (compensation.intro) {
+      children.push({ type: 'paragraph', role: 'compIntro', text: getTextIn(compensation.intro, lang) });
+    }
+
+    children.push({
+      type: 'paragraph', role: 'compWarning',
+      text: getTextIn({
+        ko: '※ 본 섹션은 비공개 협상용 자료입니다. 외부 유출 금지.',
+        en: '※ This section is private negotiation material. Do not distribute externally.'
+      }, lang)
+    });
+
+    if (compensation.currentPackage) {
+      children.push({
+        type: 'paragraph', role: 'compBlockTitle', variant: 'package',
+        text: getTextIn(compensation.currentPackage.label, lang) || ''
+      });
+      children.push({
+        type: 'keyValueList', role: 'compComponents',
+        entries: (compensation.currentPackage.components || []).map(c => ({
+          label: getTextIn(c.label, lang),
+          value: c.value || ''
+        }))
+      });
+      if (compensation.currentPackage.estimatedAnnualEv) {
+        children.push({
+          type: 'paragraph', role: 'compEstimate',
+          text: getTextIn(compensation.currentPackage.estimatedAnnualEv, lang)
+        });
+      }
+    }
+
+    const tiers = compensation.tiers || [];
+    if (tiers.length > 0) {
+      children.push({
+        type: 'table', role: 'compTiers',
+        header: [
+          { ko: '시나리오', en: 'Tier' },
+          { ko: '기본급', en: 'Base' },
+          { ko: '사이닝', en: 'Signing' },
+          { ko: '인센티브', en: 'Incentive' },
+          { ko: '옵션/RSU', en: 'Options/RSU' },
+          { ko: '1년차 총보상', en: '1Y Total' }
+        ].map(h => getTextIn(h, lang)),
+        rows: tiers.map(tier => [
+          tier.label, tier.base, tier.signing, tier.incentive, tier.options, tier.totalFirstYear
+        ].map(v => getTextIn(v, lang) || ''))
+      });
+
+      const rationales = tiers
+        .filter(tier => tier.rationale)
+        .map(tier => ({ label: getTextIn(tier.label, lang), value: getTextIn(tier.rationale, lang) }));
+      if (rationales.length > 0) {
+        children.push({ type: 'keyValueList', role: 'compRationales', entries: rationales });
+      }
+    }
+
+    if (Array.isArray(compensation.nonNegotiables) && compensation.nonNegotiables.length) {
+      children.push({
+        type: 'paragraph', role: 'compBlockTitle', variant: 'terms',
+        text: getTextIn({ ko: '비협상 조건', en: 'Non-negotiable Terms' }, lang)
+      });
+      children.push({
+        type: 'bulletList', role: 'compNonNegotiables',
+        items: compensation.nonNegotiables.map(item => ({ text: getTextIn(item, lang) }))
+      });
+    }
+
+    if (compensation.negotiationStance) {
+      children.push({
+        type: 'paragraph', role: 'compBlockTitle', variant: 'stance',
+        text: getTextIn({ ko: '협상 입장', en: 'Negotiation Stance' }, lang)
+      });
+      children.push({
+        type: 'paragraph', role: 'compStance',
+        text: getTextIn(compensation.negotiationStance, lang)
+      });
+    }
+
+    if (compensation.lastUpdated) {
+      children.push({
+        type: 'paragraph', role: 'compLastUpdated',
+        text: getTextIn({
+          ko: `최종 갱신: ${compensation.lastUpdated}`,
+          en: `Last updated: ${compensation.lastUpdated}`
+        }, lang)
+      });
+    }
+
+    return { type: 'section', id: 'compensation', children };
+  }
+
+  // ── Testimonials ────────────────────────────────────────────────────────
+
+  function buildTestimonialGroup(t, featured, lang) {
+    const children = [];
+    const hasLabels = !!(t.labels && t.labels.length > 0);
+
+    // Rendered by the PDF walker only (legacy DOCX had no featured marker).
+    if (featured) {
+      children.push({ type: 'paragraph', role: 'testimonialFeaturedTag', text: '[ Featured Testimonial ]' });
+    }
+
+    if (t.quote || t.text) {
+      children.push({
+        type: 'paragraph', role: 'testimonialQuote',
+        text: stripHtml(getTextIn(t.quote, lang) || getTextIn(t.text, lang))
+      });
+    }
+
+    const authorRuns = [];
+    if (t.author || t.name) {
+      authorRuns.push({ text: getTextIn(t.author, lang) || getTextIn(t.name, lang), role: 'author' });
+    }
+    if (t.role) authorRuns.push({ text: getTextIn(t.role, lang), role: 'authorRole' });
+    if (t.relation) authorRuns.push({ text: getTextIn(t.relation, lang), role: 'relation' });
+    children.push({ type: 'paragraph', role: 'testimonialAuthor', runs: authorRuns, keepWithNext: hasLabels });
+
+    if (hasLabels) {
+      children.push({
+        type: 'badgeRow', role: 'testimonialLabels',
+        items: t.labels.map(l => getTextIn(l.text, lang))
+      });
+    }
+
+    return { type: 'group', role: 'testimonial', featured, children };
+  }
+
+  function buildTestimonialsSection(testimonials, labels, lang) {
+    const children = [{ type: 'heading', level: 2, role: 'section', text: labels.testimonials }];
+
+    const ordered = [];
+    if (testimonials.featured) ordered.push({ t: testimonials.featured, featured: true });
+    if (testimonials.testimonials && testimonials.testimonials.length > 0) {
+      testimonials.testimonials.forEach(t => ordered.push({ t, featured: false }));
+    }
+
+    ordered.forEach(({ t, featured }, idx) => {
+      if (idx > 0) children.push({ type: 'spacer', role: 'testimonialDivider' });
+      children.push(buildTestimonialGroup(t, featured, lang));
+    });
+
+    return { type: 'section', id: 'testimonials', children };
+  }
+
+  // ── Manager / leadership ────────────────────────────────────────────────
+
+  function computeCapabilityChips(metrics, lang) {
+    const m = metrics || {};
+    const chips = [];
+    if (Array.isArray(m.teamSizes) && m.teamSizes.length > 0) {
+      const min = Math.min(...m.teamSizes), max = Math.max(...m.teamSizes);
+      chips.push(`${lang === 'ko' ? '팀 규모' : 'Team Size'} ${min}–${max}`);
+    }
+    if (m.yearsLeading) chips.push(`${lang === 'ko' ? '리딩 연차' : 'Leading'} ${m.yearsLeading}+ ${lang === 'ko' ? '년' : 'yrs'}`);
+    if (m.projectsLed) chips.push(`${lang === 'ko' ? '리딩 프로젝트' : 'Projects Led'} ${m.projectsLed}+`);
+    if (m.onTimeDelivery) chips.push(`${lang === 'ko' ? '정시 납품' : 'On-Time'} ${m.onTimeDelivery}`);
+    if (m.certificationSuccess) chips.push(`${lang === 'ko' ? '인증 성공률' : 'Cert Success'} ${m.certificationSuccess}`);
+    if (m.majorProjects) chips.push(`${lang === 'ko' ? '주요 프로젝트' : 'Major Projects'} ${m.majorProjects}+`);
+    return chips;
+  }
+
+  function buildManagerSection(manager, labels, lang) {
+    const children = [{ type: 'heading', level: 2, role: 'section', text: labels.manager }];
+
+    if (manager.pmCapabilities && manager.pmCapabilities.length > 0) {
+      children.push({ type: 'heading', level: 3, role: 'subsection', text: labels.pmCapabilities, pageBreakBefore: false });
+
+      manager.pmCapabilities.forEach((cap, idx) => {
+        const g = { type: 'group', role: 'pmCapability', children: [] };
+
+        g.children.push({
+          type: 'paragraph', role: 'pmCapTitle',
+          text: getTextIn(cap.title, lang), first: idx === 0
+        });
+        if (cap.description) {
+          g.children.push({ type: 'paragraph', role: 'pmCapDescription', text: getTextIn(cap.description, lang) });
+        }
+
+        const highlights = getArrayIn(cap.highlights, lang);
+        if (highlights.length > 0) {
+          g.children.push({
+            type: 'bulletList', role: 'pmCapHighlights',
+            items: highlights.map(h => ({ text: stripHtml(getTextIn(h, lang)) }))
+          });
+        }
+
+        const chips = computeCapabilityChips(cap.metrics, lang);
+        if (chips.length > 0) {
+          g.children.push({ type: 'badgeRow', role: 'pmCapMetrics', items: chips });
+        }
+
+        const tags = getArrayIn(cap.stakeholderTypes, lang).concat(cap.frameworks || []);
+        if (tags.length > 0) {
+          g.children.push({ type: 'badgeRow', role: 'pmCapTags', items: tags.map(t => getTextIn(t, lang)) });
+        }
+
+        children.push(g);
+      });
+
+      // Rendered by the PDF walker only (legacy trailing gap node).
+      children.push({ type: 'spacer', role: 'pmCapabilitiesEnd' });
+    }
+
+    if (manager.leadershipStyle) {
+      const principles = getArrayIn(manager.leadershipStyle.principles, lang);
+      if (principles.length > 0) {
+        children.push({ type: 'heading', level: 3, role: 'subsection', text: labels.leadershipStyle, pageBreakBefore: false });
+        children.push({
+          type: 'bulletList', role: 'managerPrinciples',
+          items: principles.map(p => ({ text: stripHtml(getTextIn(p, lang)) }))
+        });
+      }
+    }
+
+    if (manager.businessImpact) {
+      // keyNumbers omitted - already shown on the cover-page stat infographic.
+      const highlights = getArrayIn(manager.businessImpact.highlights, lang);
+      if (highlights.length > 0) {
+        children.push({ type: 'heading', level: 3, role: 'subsection', text: labels.businessImpact, pageBreakBefore: false });
+        children.push({
+          type: 'bulletList', role: 'managerImpact',
+          items: highlights.map(h => ({ text: stripHtml(getTextIn(h, lang)) }))
+        });
+      }
+    }
+
+    if (manager.softSkills && manager.softSkills.length > 0) {
+      children.push({ type: 'heading', level: 3, role: 'subsection', text: labels.softSkills, pageBreakBefore: false });
+      children.push({
+        type: 'table', role: 'softSkillsGrid',
+        cells: manager.softSkills.map(skill => ({
+          title: getTextIn(skill.title, lang),
+          description: skill.description ? getTextIn(skill.description, lang) : null
+        }))
+      });
+    }
+
+    return { type: 'section', id: 'manager', children };
+  }
+
+  // ── Document assembly ───────────────────────────────────────────────────
+
+  /**
+   * Build the format-neutral export tree.
+   * @param {Object} data - Portfolio data (same shape the exporters receive)
+   * @param {Object} options - Export info/options
+   * @param {Array}  options.sections - Content section ids in render order
+   * @param {string} options.title - Document title
+   * @param {string} options.author - Document author
+   * @param {boolean} options.includeCoverPage
+   * @param {boolean} options.includeCoverLetter
+   * @param {Object}  options.coverLetterTemplate
+   * @param {boolean} options.pageBreakBetweenSections
+   * @param {Array}   options.personalInfoFields - Selected profile field ids
+   * @param {string} lang - Language code ('ko' or 'en')
+   * @returns {Object} document node
+   */
+  function build(data, options = {}, lang = 'ko') {
+    const {
+      sections = ['expertise', 'manager', 'projects', 'career', 'education', 'testimonials'],
+      title = lang === 'ko' ? '포트폴리오' : 'Portfolio',
+      author = lang === 'ko' ? '신동철' : 'Dongcheol Shin',
+      includeCoverPage = true,
+      includeCoverLetter = false,
+      coverLetterTemplate = null,
+      pageBreakBetweenSections = true,
+      personalInfoFields = []
+    } = options;
+
+    const labels = window.ExportContent.getLabels(lang);
+    const children = [];
+
+    if (includeCoverPage) {
+      children.push(buildCoverSection(data, { title, author, personalInfoFields }, lang));
+    }
+    if (includeCoverLetter && coverLetterTemplate) {
+      children.push(buildCoverLetterSection(coverLetterTemplate, includeCoverPage, lang));
+    }
+    if (!includeCoverPage) {
+      children.push(buildInlineHeaderSection({ title, author }, lang));
+    }
+
+    // With a cover page or cover letter ahead, every content section starts
+    // on a new page; otherwise only break between sections (skip the first).
+    // The section-array index is used (not the rendered index) so a leading
+    // section without data does not change the breaks of the following ones.
+    const headPlaced = includeCoverPage || includeCoverLetter;
+    sections.forEach((sectionId, index) => {
+      const pageBreakBefore = headPlaced ? true : (pageBreakBetweenSections && index > 0);
+      let node = null;
+      switch (sectionId) {
+        case 'expertise':
+          if (data.expertise) node = buildExpertiseSection(data.expertise, labels, lang);
+          break;
+        case 'projects':
+          if (data.projects) node = buildProjectsSection(data.projects, labels, lang);
+          break;
+        case 'career':
+          if (data.career) node = buildCareerSection(data.career, labels, lang);
+          break;
+        case 'testimonials':
+          if (data.testimonials) node = buildTestimonialsSection(data.testimonials, labels, lang);
+          break;
+        case 'manager':
+          if (data.manager) node = buildManagerSection(data.manager, labels, lang);
+          break;
+        case 'education':
+          if (data.education) node = buildEducationSection(data.education, labels, lang);
+          break;
+        case 'compensation':
+          if (data.compensation) node = buildCompensationSection(data.compensation, labels, lang);
+          break;
+      }
+      if (node) {
+        node.pageBreakBefore = pageBreakBefore;
+        // Stamp the section heading too, so walkers can emit it directly.
+        const first = node.children[0];
+        if (first && first.type === 'heading' && first.level === 2) {
+          first.pageBreakBefore = pageBreakBefore;
+        }
+        children.push(node);
+      }
+    });
+
+    return { type: 'document', lang, title, author, includeCoverPage, children };
+  }
+
+  // Export for browser global access
+  window.ExportIR = { build };
+})();

--- a/portfolio/admin/utils/pdf-exporter.js
+++ b/portfolio/admin/utils/pdf-exporter.js
@@ -2,13 +2,20 @@
  * PDF Exporter - Generate PDF from portfolio data using pdfmake
  * Supports theme-based styling via StyleManager
  *
- * Dependencies: utils/i18n.js (getLang), utils/export-content.js
- * (shared labels, cover-page content, duration calculation)
+ * Content (sections, field order, labels, localized strings) comes from the
+ * format-neutral tree built by utils/export-ir.js (window.ExportIR); this
+ * file only maps IR nodes to pdfmake constructs and owns every styling
+ * decision (colors, typography, spacing, unbreakable blocks) plus the
+ * Korean font loading.
+ *
+ * Dependencies: utils/i18n.js (getLang), utils/export-content.js (labels),
+ * utils/export-ir.js (IR)
  */
 
 class PDFExporter {
   constructor() {
     this.fontLoaded = false;
+    this.boldFontLoaded = false;
     this.fontLoading = null;
     this.currentTheme = null;
     this.themeStyles = null;
@@ -21,61 +28,6 @@ class PDFExporter {
    */
   getLang() {
     return window.i18nUtils?.getLang?.() || window.currentLanguage || window.getLanguage?.() || 'ko';
-  }
-
-  /**
-   * Get text from multilingual object (delegates to shared utility)
-   * @param {*} obj - Multilingual object or string
-   * @returns {string} Text in current language
-   */
-  getText(obj) {
-    // Use shared utility with currentLang context
-    if (!obj) return '';
-    if (typeof obj === 'string') return obj;
-    const lang = this.currentLang;
-    return obj[lang] || obj.ko || obj.en || '';
-  }
-
-  /**
-   * Get array from multilingual object (delegates to shared utility)
-   * @param {*} obj - Multilingual array object or array
-   * @returns {Array} Array in current language
-   */
-  getArray(obj) {
-    if (!obj) return [];
-    if (Array.isArray(obj)) return obj;
-    const lang = this.currentLang;
-    return obj[lang] || obj.ko || obj.en || [];
-  }
-
-  /**
-   * Calculate duration from period string (delegates to shared ExportContent,
-   * which takes the language as an explicit argument — no global state swap)
-   * @param {string|Object} period - Period string or multilingual object
-   * @returns {string|null} Formatted duration string
-   */
-  calculateDuration(period) {
-    return window.ExportContent.calculateDuration(period, this.currentLang);
-  }
-
-  /**
-   * Format period with duration
-   * @param {string|Object} period - Period string or multilingual object
-   * @returns {string} Period with duration appended
-   */
-  formatPeriodWithDuration(period) {
-    let periodStr = this.getText(period);
-    periodStr = periodStr.replace(/\s*\([^)]*(?:개월|년|months?|yrs?|mo)[^)]*\)/gi, '').trim();
-    const duration = this.calculateDuration(period);
-    return duration ? `${periodStr} (${duration})` : periodStr;
-  }
-
-  /**
-   * Get localized labels (delegates to the shared ExportContent dictionary)
-   * @returns {Object} Localized label strings
-   */
-  getLabels() {
-    return window.ExportContent.getLabels(this.currentLang);
   }
 
   /**
@@ -420,29 +372,59 @@ class PDFExporter {
   }
 
   /**
-   * Load Korean font (Noto Sans KR) for PDF generation
+   * Load Korean fonts (Noto Sans KR Regular + Bold) for PDF generation.
+   *
+   * Regular is required: without it Korean exports would render broken
+   * Hangul glyphs, so callers treat its failure as fatal for 'ko'.
+   * Bold is optional: when it fails, every weight falls back to Regular
+   * and the export proceeds (bold hierarchy is lost, not the text).
+   *
+   * The result is memoized via this.fontLoading so repeated exports do
+   * not refetch either font.
+   *
+   * @returns {Promise<{regular: boolean, bold: boolean}>} Load status per weight
    */
   async loadKoreanFont() {
-    if (this.fontLoaded) return true;
+    if (this.fontLoaded) return { regular: true, bold: this.boldFontLoaded };
     if (this.fontLoading) return this.fontLoading;
 
     this.fontLoading = (async () => {
       try {
-        // Noto Sans KR Regular from Google Fonts
-        const fontUrl = 'https://fonts.gstatic.com/s/notosanskr/v36/PbyxFmXiEBPT4ITbgNA5Cgms3VYcOA-vvnIzzuoyeLTq8H4hfeE.ttf';
+        // Noto Sans KR from Google Fonts
+        const regularUrl = 'https://fonts.gstatic.com/s/notosanskr/v36/PbyxFmXiEBPT4ITbgNA5Cgms3VYcOA-vvnIzzuoyeLTq8H4hfeE.ttf';
+        const boldUrl = 'https://fonts.gstatic.com/s/notosanskr/v39/PbyxFmXiEBPT4ITbgNA5Cgms3VYcOA-vvnIzzg01eLQ.ttf';
 
-        const response = await fetch(fontUrl);
-        if (!response.ok) {
-          console.warn('Korean font load failed, using default font');
-          return false;
+        const fetchFont = async (url) => {
+          const response = await fetch(url);
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+          return this.arrayBufferToBase64(await response.arrayBuffer());
+        };
+
+        const [regularResult, boldResult] = await Promise.allSettled([
+          fetchFont(regularUrl),
+          fetchFont(boldUrl)
+        ]);
+
+        if (regularResult.status !== 'fulfilled') {
+          console.warn('Korean font load failed, using default font:', regularResult.reason);
+          return { regular: false, bold: false };
         }
 
-        const fontBuffer = await response.arrayBuffer();
-        const base64 = this.arrayBufferToBase64(fontBuffer);
+        const boldOk = boldResult.status === 'fulfilled';
+        if (!boldOk) {
+          console.warn('Korean bold font load failed, using Regular for bold text:', boldResult.reason);
+        }
 
-        // Register font with pdfMake
+        // Register fonts with pdfMake. When Bold is unavailable, map the
+        // bold weights back to Regular so the export still succeeds.
         pdfMake.vfs = pdfMake.vfs || {};
-        pdfMake.vfs['NotoSansKR-Regular.ttf'] = base64;
+        pdfMake.vfs['NotoSansKR-Regular.ttf'] = regularResult.value;
+        if (boldOk) {
+          pdfMake.vfs['NotoSansKR-Bold.ttf'] = boldResult.value;
+        }
+        const boldFile = boldOk ? 'NotoSansKR-Bold.ttf' : 'NotoSansKR-Regular.ttf';
 
         pdfMake.fonts = {
           Roboto: {
@@ -453,18 +435,21 @@ class PDFExporter {
           },
           NotoSansKR: {
             normal: 'NotoSansKR-Regular.ttf',
-            bold: 'NotoSansKR-Regular.ttf',
+            bold: boldFile,
             italics: 'NotoSansKR-Regular.ttf',
-            bolditalics: 'NotoSansKR-Regular.ttf'
+            bolditalics: boldFile
           }
         };
 
         this.fontLoaded = true;
-        console.log('Korean font loaded successfully');
-        return true;
+        this.boldFontLoaded = boldOk;
+        console.log(boldOk
+          ? 'Korean fonts loaded successfully (Regular + Bold)'
+          : 'Korean font loaded (Regular only, Bold unavailable)');
+        return { regular: true, bold: boldOk };
       } catch (error) {
         console.warn('Korean font load error:', error);
-        return false;
+        return { regular: false, bold: false };
       }
     })();
 
@@ -525,16 +510,21 @@ class PDFExporter {
       // Initialize theme
       this.initializeTheme(theme, themeOverrides);
 
-      // Load Korean font first. Without it a Korean export would silently
-      // produce broken Hangul glyphs (Roboto has none), so abort in that
-      // case; English exports proceed with a warning attached to the result.
-      const fontOk = await this.loadKoreanFont();
-      if (!fontOk && this.currentLang === 'ko') {
+      // Load Korean fonts first. Without Regular a Korean export would
+      // silently produce broken Hangul glyphs (Roboto has none), so abort
+      // in that case; English exports proceed with a warning attached to
+      // the result. A missing Bold weight is never fatal: the export
+      // proceeds with Regular substituted and a warning attached.
+      const fontStatus = await this.loadKoreanFont();
+      if (!fontStatus.regular && this.currentLang === 'ko') {
         throw new Error('Korean font (Noto Sans KR) could not be loaded - aborting PDF export to avoid broken Hangul text. Check the network connection and retry.');
       }
-      const fontWarning = fontOk
-        ? null
-        : 'Korean font unavailable - PDF generated with the Latin-only Roboto font.';
+      let fontWarning = null;
+      if (!fontStatus.regular) {
+        fontWarning = 'Korean font unavailable - PDF generated with the Latin-only Roboto font.';
+      } else if (!fontStatus.bold) {
+        fontWarning = 'Korean bold font unavailable - bold text is rendered in the regular weight.';
+      }
 
       // Load cover letter if requested
       let coverLetterTemplate = null;
@@ -613,84 +603,22 @@ class PDFExporter {
   }
 
   /**
-   * Build pdfmake document definition
+   * Build pdfmake document definition from the format-neutral IR tree
    */
   buildDocument(data, sections, info) {
+    const ir = window.ExportIR.build(data, {
+      sections,
+      title: info.title,
+      author: info.author,
+      includeCoverPage: info.includeCoverPage,
+      includeCoverLetter: info.includeCoverLetter,
+      coverLetterTemplate: info.coverLetterTemplate,
+      pageBreakBetweenSections: info.pageBreakBetweenSections,
+      personalInfoFields: info.personalInfoFields
+    }, this.currentLang);
+
     const content = [];
-    const {
-      includeCoverLetter = false,
-      coverLetterTemplate = null,
-      includeCoverPage = true,
-      pageBreakBetweenSections = true,
-      personalInfoFields = []
-    } = info;
-
-    // Cover Page (hero + stats infographic)
-    if (includeCoverPage) {
-      content.push(...this.buildCoverPage(info, data, { personalInfoFields }));
-    }
-
-    // Cover Letter (if included). When the cover page precedes it, force
-    // the letter onto a new page by setting pageBreak:'before' on its first
-    // node — no trailing break (the next section header handles that one).
-    if (includeCoverLetter && coverLetterTemplate) {
-      const letter = this.buildCoverLetterPage(coverLetterTemplate);
-      if (includeCoverPage && letter.length > 0) {
-        letter[0].pageBreak = 'before';
-      }
-      content.push(...letter);
-    }
-
-    // Inline header (only when no cover page is used)
-    if (!includeCoverPage) {
-      content.push(this.buildHeader(info));
-    }
-
-    // Build each section. With a cover page, every section starts on a new page;
-    // otherwise, only break between sections (skip first).
-    sections.forEach((section, index) => {
-      const addPageBreak = includeCoverPage
-        ? true
-        : (pageBreakBetweenSections && index > 0);
-
-      switch (section) {
-        case 'expertise':
-          if (data.expertise) {
-            content.push(...this.buildExpertiseSection(data.expertise, addPageBreak));
-          }
-          break;
-        case 'projects':
-          if (data.projects) {
-            content.push(...this.buildProjectsSection(data.projects, addPageBreak));
-          }
-          break;
-        case 'career':
-          if (data.career) {
-            content.push(...this.buildCareerSection(data.career, addPageBreak));
-          }
-          break;
-        case 'testimonials':
-          if (data.testimonials) {
-            content.push(...this.buildTestimonialsSection(data.testimonials, addPageBreak));
-          }
-          break;
-        case 'manager':
-          if (data.manager) {
-            content.push(...this.buildManagerSection(data.manager, addPageBreak));
-          }
-          break;
-        case 'education':
-          if (data.education) {
-            content.push(...this.buildEducationSection(data.education, addPageBreak));
-          }
-          break;
-        case 'compensation':
-          if (data.compensation) {
-            content.push(...this.buildCompensationSection(data.compensation, addPageBreak));
-          }
-          break;
-      }
-    });
+    ir.children.forEach(section => content.push(...this.renderSection(section)));
 
     // Use theme-based page margins
     const pageMargins = this.themeStyles?.pageMargins || [
@@ -702,14 +630,14 @@ class PDFExporter {
 
     return {
       info: {
-        title: info.title,
-        author: info.author,
+        title: ir.title,
+        author: ir.author,
         subject: 'Professional Portfolio',
         creator: 'Portfolio Admin'
       },
       pageSize: 'A4',
       pageMargins,
-      footer: this.getDocFooter(info),
+      footer: this.getDocFooter(ir),
       defaultStyle: {
         font: this.fontLoaded ? 'NotoSansKR' : 'Roboto',
         fontSize: this.getTypography('fontSize.body'),
@@ -721,211 +649,890 @@ class PDFExporter {
     };
   }
 
+  // ── IR walkers ──────────────────────────────────────────────────────────
+
   /**
-   * Build cover letter page
-   * @param {Object} template - Cover letter template object
-   * @returns {Array} pdfmake content array for cover letter
+   * Render one IR section to an array of pdfmake content nodes
+   * @param {Object} section - IR section node
+   * @returns {Array} pdfmake content nodes
    */
-  buildCoverLetterPage(template) {
-    const lang = this.currentLang;
-    const content = [];
-
-    // Greeting
-    content.push({
-      text: this.getText(template.greeting),
-      fontSize: this.getTypography('fontSize.body'),
-      margin: [0, 0, 0, this.getSpacing('section.gap') * 1.5]
-    });
-
-    // Opening paragraph (with variable substitution)
-    const position = this.getText(template.targetRole);
-    const opening = this.getText(template.opening).replace('{position}', position);
-    content.push({
-      text: opening,
-      fontSize: this.getTypography('fontSize.body'),
-      lineHeight: this.getTypography('lineHeight') * 1.1,
-      alignment: 'justify',
-      margin: [0, 0, 0, this.getSpacing('section.gap') * 1.5]
-    });
-
-    // Key points
-    const keyPointsContent = [];
-    const keyPoints = this.getArray(template.keyPoints);
-    keyPoints.forEach(point => {
-      const text = this.getText(point);
-      // Convert **text** to bold
-      const parts = text.split(/\*\*(.+?)\*\*/g);
-      const formattedText = parts.map((part, index) => {
-        if (index % 2 === 1) {
-          // Odd indices are inside **...**
-          return { text: part, bold: true, color: this.getColor('primary') };
-        }
-        return part;
-      });
-
-      keyPointsContent.push({
-        text: formattedText,
-        margin: [0, 0, 0, this.getSpacing('list.itemGap') * 1.2]
-      });
-    });
-
-    content.push({
-      ul: keyPointsContent,
-      margin: [0, 0, 0, this.getSpacing('section.gap') * 1.5]
-    });
-
-    // Closing paragraph
-    content.push({
-      text: this.getText(template.closing),
-      fontSize: this.getTypography('fontSize.body'),
-      lineHeight: this.getTypography('lineHeight') * 1.1,
-      alignment: 'justify',
-      margin: [0, 0, 0, this.getSpacing('section.gap') * 2]
-    });
-
-    // Signature
-    content.push({
-      text: this.getText(template.signature),
-      fontSize: this.getTypography('fontSize.body'),
-      margin: [0, 0, 0, 0]
-    });
-
-    return content;
+  renderSection(section) {
+    const out = this.renderNodes(section.children, {});
+    // The cover letter starts on a new page by setting pageBreak:'before' on
+    // its first node — no trailing break (the next section header handles
+    // that one). Content-section headings carry their own pageBreakBefore.
+    if (section.id === 'coverLetter' && section.pageBreakBefore && out.length > 0) {
+      out[0].pageBreak = 'before';
+    }
+    return out;
   }
 
   /**
-   * Build cover page with hero block and stats infographic
-   * @param {Object} info - Document info ({title, author})
-   * @param {Object} data - Full portfolio data
-   * @returns {Array} pdfmake content array (ends with page break)
+   * Render a list of IR nodes
+   * @param {Array} nodes - IR nodes
+   * @param {Object} ctx - Render context (e.g. featured testimonial flag)
+   * @returns {Array} pdfmake content nodes
    */
-  buildCoverPage(info, data, opts = {}) {
-    const content = [];
-    const lang = this.currentLang;
-    const selectedFieldIds = Array.isArray(opts.personalInfoFields) ? opts.personalInfoFields : [];
-    const showPersonalInfo = selectedFieldIds.length > 0;
-    const locale = lang === 'ko' ? 'ko-KR' : 'en-US';
-    const dateStr = new Date().toLocaleDateString(locale, {
-      year: 'numeric', month: 'long', day: 'numeric'
-    });
+  renderNodes(nodes, ctx) {
+    const out = [];
+    (nodes || []).forEach(node => out.push(...this.renderNode(node, ctx)));
+    return out;
+  }
 
-    // Subtitle and summary come from the shared ExportContent module
-    // (profile data first, shared constants as fallback).
-    const subtitle = window.ExportContent.getCoverSubtitle(lang, data.profile);
-    const summaryLines = window.ExportContent.getCoverSummaryLines(lang, data.profile);
+  /**
+   * Render a single IR node
+   * @param {Object} node - IR node
+   * @param {Object} ctx - Render context
+   * @returns {Array} pdfmake content nodes
+   */
+  renderNode(node, ctx) {
+    switch (node.type) {
+      case 'group': return this.renderGroup(node, ctx);
+      case 'heading': return this.renderHeading(node);
+      case 'paragraph': return this.renderParagraph(node, ctx);
+      case 'bulletList': return this.renderBulletListNode(node);
+      case 'keyValueList': return this.renderKeyValueList(node);
+      case 'badgeRow': return this.renderBadgeRow(node);
+      case 'table': return this.renderTable(node);
+      case 'statsRow': return this.renderStatsRow(node);
+      case 'spacer': return this.renderSpacer(node);
+      default: return [];
+    }
+  }
 
-    content.push({
-      canvas: [{ type: 'rect', x: 0, y: 0, w: 60, h: 3, color: this.getColor('primary') }],
-      margin: [0, 40, 0, 48]
-    });
+  /**
+   * Render an IR group as an unbreakable stack (role decides the margin)
+   */
+  renderGroup(node, ctx) {
+    switch (node.role) {
+      case 'expertiseCategory':
+        return [{
+          unbreakable: true,
+          stack: this.renderNodes(node.children, ctx),
+          margin: [0, 0, 0, this.getSpacing('gap.medium')]
+        }];
+      case 'heroCapabilities':
+      case 'certifications':
+        return [{
+          unbreakable: true,
+          stack: this.renderNodes(node.children, ctx),
+          margin: [0, 0, 0, 5]
+        }];
+      case 'project':
+        // Card-like block. Bottom margin sized to keep projects distinct
+        // without leaving large gaps on the page.
+        return [{
+          unbreakable: true,
+          stack: this.renderNodes(node.children, ctx),
+          margin: [0, 0, 0, 22]
+        }];
+      case 'careerEntry':
+        return [{
+          unbreakable: true,
+          stack: this.renderNodes(node.children, ctx),
+          margin: [0, 0, 0, this.getSpacing('gap.xlarge')]
+        }];
+      case 'educationEntry':
+        return [{
+          unbreakable: true,
+          stack: this.renderNodes(node.children, ctx),
+          margin: [0, 0, 0, this.getSpacing('gap.medium')]
+        }];
+      case 'testimonial':
+        return [{
+          unbreakable: true,
+          stack: this.renderNodes(node.children, { ...ctx, featured: !!node.featured }),
+          margin: [0, 14, 0, 22]
+        }];
+      case 'pmCapability':
+        return [{
+          unbreakable: true,
+          stack: this.renderNodes(node.children, ctx),
+          margin: [0, 0, 0, 4]
+        }];
+      default:
+        return this.renderNodes(node.children, ctx);
+    }
+  }
 
-    // Name — 32pt per Microsoft Word resume guide (28–35pt range)
-    content.push({
-      text: info.author || info.title,
-      fontSize: 32,
-      bold: true,
-      color: this.getColor('text.primary'),
-      lineHeight: 1.15,
-      margin: [0, 0, 0, 10]
-    });
+  /**
+   * Render an IR heading node
+   */
+  renderHeading(node) {
+    switch (node.role) {
+      case 'section':
+        return this.buildSectionHeader(node.text, !!node.pageBreakBefore);
+      case 'subsection':
+        return this.buildSubsectionHeader(node.text, !!node.pageBreakBefore);
+      case 'expertiseCategory':
+        // Category title with enhanced primary color
+        return [{
+          text: '[ ' + node.text + ' ]',
+          fontSize: this.getTypography('fontSize.h3'),
+          color: '#3B82F6',  // Primary blue matching web design
+          bold: true,
+          margin: [0, this.getSpacing('subsection.marginTop'), 0, this.getSpacing('subsection.marginBottom')]
+        }];
+      case 'coreCapabilities':
+        return [{
+          text: node.text,
+          style: 'sectionTitle'
+        }];
+      case 'certifications':
+        return [{
+          text: node.text,
+          fontSize: this.getTypography('fontSize.h3'),
+          color: '#3B82F6',  // Primary blue
+          bold: true,
+          margin: [0, 18, 0, 8]
+        }];
+      default:
+        return [];
+    }
+  }
 
-    // Subtitle / role line
-    content.push({
-      text: subtitle,
-      fontSize: 12,
-      color: this.getColor('primary'),
-      bold: true,
-      characterSpacing: 1.5,
-      margin: [0, 0, 0, showPersonalInfo ? 12 : 26]
-    });
+  /**
+   * Render an IR paragraph node (role decides the exact typography)
+   */
+  renderParagraph(node, ctx) {
+    switch (node.role) {
+      // ── Cover page ────────────────────────────────────────────────
+      case 'coverName':
+        // Name — 32pt per Microsoft Word resume guide (28–35pt range)
+        return [{
+          text: node.text,
+          fontSize: 32,
+          bold: true,
+          color: this.getColor('text.primary'),
+          lineHeight: 1.15,
+          margin: [0, 0, 0, 10]
+        }];
 
-    // Optional personal info row — only the field IDs the user selected.
-    if (showPersonalInfo && data.profile && Array.isArray(data.profile.fields)) {
-      const byId = new Map(data.profile.fields.map(f => [f.id, f]));
-      const parts = selectedFieldIds
-        .map(id => byId.get(id))
-        .filter(Boolean)
-        .map(f => this.getText(f.value))
-        .filter(v => v && v.length > 0);
-      if (parts.length) {
-        content.push({
-          text: parts.join('   ·   '),
+      case 'coverSubtitle':
+        return [{
+          text: node.text,
+          fontSize: 12,
+          color: this.getColor('primary'),
+          bold: true,
+          characterSpacing: 1.5,
+          margin: [0, 0, 0, node.tight ? 12 : 26]
+        }];
+
+      case 'coverPersonalInfo':
+        return [{
+          text: node.text,
           fontSize: 9.5,
           color: this.getColor('text.secondary'),
           margin: [0, 0, 0, 22]
-        });
+        }];
+
+      case 'coverSummary':
+        // Executive summary — single block, lines joined with newlines
+        return [{
+          text: node.lines.join('\n'),
+          fontSize: 10.5,
+          color: this.getColor('text.secondary'),
+          lineHeight: 1.6,
+          margin: [0, 0, 0, 30]
+        }];
+
+      case 'coverCertsLabel':
+        return [{
+          text: node.text,
+          fontSize: 9,
+          color: this.getColor('text.muted'),
+          bold: true,
+          margin: [0, 28, 0, 6]
+        }];
+
+      case 'coverCertsText':
+        return [{
+          text: node.text,
+          fontSize: 11,
+          color: this.getColor('success'),
+          bold: true,
+          margin: [0, 0, 0, 0]
+        }];
+
+      case 'coverDate':
+        return [{
+          text: node.text,
+          fontSize: 9,
+          color: this.getColor('text.muted'),
+          alignment: 'right',
+          margin: [0, 60, 0, 0]
+        }];
+
+      // ── Cover letter ──────────────────────────────────────────────
+      case 'clGreeting':
+        return [{
+          text: node.text,
+          fontSize: this.getTypography('fontSize.body'),
+          margin: [0, 0, 0, this.getSpacing('section.gap') * 1.5]
+        }];
+
+      case 'clOpening':
+        return [{
+          text: node.text,
+          fontSize: this.getTypography('fontSize.body'),
+          lineHeight: this.getTypography('lineHeight') * 1.1,
+          alignment: 'justify',
+          margin: [0, 0, 0, this.getSpacing('section.gap') * 1.5]
+        }];
+
+      case 'clClosing':
+        return [{
+          text: node.text,
+          fontSize: this.getTypography('fontSize.body'),
+          lineHeight: this.getTypography('lineHeight') * 1.1,
+          alignment: 'justify',
+          margin: [0, 0, 0, this.getSpacing('section.gap') * 2]
+        }];
+
+      case 'clSignature':
+        return [{
+          text: node.text,
+          fontSize: this.getTypography('fontSize.body'),
+          margin: [0, 0, 0, 0]
+        }];
+
+      // ── Inline header (no cover page) ─────────────────────────────
+      case 'inlineHeader': {
+        const titleRun = node.runs.find(r => r.role === 'title');
+        const dateRun = node.runs.find(r => r.role === 'date');
+        return [{
+          columns: [
+            {
+              text: titleRun ? titleRun.text : '',
+              fontSize: this.getTypography('fontSize.h1'),
+              bold: true,
+              color: this.getColor('primary')  // Use primary color directly instead of style
+            },
+            {
+              text: dateRun ? dateRun.text : '',
+              alignment: 'right',
+              fontSize: this.getTypography('fontSize.small'),
+              color: this.getColor('text.muted'),
+              margin: [0, 8, 0, 0],
+              width: 'auto'
+            }
+          ],
+          margin: [0, 0, 0, this.getSpacing('header.marginBottom')]
+        }];
       }
+
+      // ── Projects ──────────────────────────────────────────────────
+      case 'projectTitle':
+        return [{
+          text: node.text,
+          bold: true,
+          fontSize: this.getTypography('fontSize.h3'),
+          color: this.getColor('primary'),  // Primary for emphasis
+          margin: [0, 0, 0, 4],
+          lineHeight: this.getTypography('lineHeight.tight')
+        }];
+
+      case 'projectMeta': {
+        const company = node.runs.find(r => r.role === 'company');
+        const period = node.runs.find(r => r.role === 'period');
+        const metaText = [];
+        if (company) {
+          metaText.push({
+            text: company.text,
+            color: this.getColor('text.secondary'),
+            bold: true
+          });
+        }
+        if (period) {
+          if (company) {
+            metaText.push({ text: ' | ', color: this.getColor('text.muted') });
+          }
+          metaText.push({
+            text: period.text,
+            color: this.getColor('accent')  // Accent color for dates
+          });
+        }
+        return [{
+          text: metaText,
+          fontSize: this.getTypography('fontSize.small'),
+          italics: true,
+          margin: [0, 0, 0, 6]
+        }];
+      }
+
+      case 'projectDescription':
+        return [{
+          text: node.text,
+          color: this.getColor('text.secondary'),
+          fontSize: this.getTypography('fontSize.body'),
+          lineHeight: this.getTypography('lineHeight.relaxed'),
+          margin: [0, 0, 0, 8]
+        }];
+
+      case 'blockLabel': {
+        // Color-coded '[ Label ]' block headers (web palette)
+        const styles = {
+          roles: { color: '#3B82F6', margin: [0, 0, 0, 4] },
+          challenges: { color: '#F59E0B', margin: [0, 6, 0, 4] },
+          solutions: { color: '#3B82F6', margin: [0, 6, 0, 4] },
+          achievements: { color: '#10B981', margin: [0, 6, 0, 4] },
+          keyAchievements: { color: '#10B981', margin: [0, 6, 0, 3] }
+        };
+        const s = styles[node.variant] || styles.roles;
+        return [{
+          text: node.text,
+          bold: true,
+          fontSize: this.getTypography('fontSize.h4'),
+          color: s.color,
+          margin: s.margin
+        }];
+      }
+
+      // ── Career ────────────────────────────────────────────────────
+      case 'careerHeader': {
+        const title = node.runs.find(r => r.role === 'title');
+        const badge = node.runs.find(r => r.role === 'badge');
+        const period = node.runs.find(r => r.role === 'period');
+        const companyText = [];
+        companyText.push({
+          text: title ? title.text : '',
+          bold: true,
+          color: '#3B82F6'  // Primary color
+        });
+        if (badge) {
+          companyText.push({
+            text: ' [' + badge.text + ']',
+            color: '#F59E0B',  // Warning color
+            bold: true
+          });
+        }
+        return [{
+          columns: [
+            {
+              text: companyText,
+              fontSize: this.getTypography('fontSize.h3'),
+              width: '*'
+            },
+            {
+              text: period ? period.text : '',
+              alignment: 'right',
+              color: '#3B82F6',  // Primary color for dates
+              fontSize: this.getTypography('fontSize.small'),
+              bold: true,
+              width: 'auto'
+            }
+          ],
+          margin: [0, 8, 0, 4]
+        }];
+      }
+
+      case 'careerRole':
+        return [{
+          text: '> ' + node.text,
+          color: '#0F172A',  // Text primary
+          fontSize: this.getTypography('fontSize.body'),
+          bold: true,
+          margin: [0, 0, 0, 4]
+        }];
+
+      case 'careerCompanyDescription':
+        return [{
+          text: node.text,
+          italics: true,
+          color: this.getColor('text.muted'),
+          fontSize: this.getTypography('fontSize.small'),
+          margin: [0, 0, 0, 3]
+        }];
+
+      case 'careerResponsibilities': {
+        const label = node.runs.find(r => r.role === 'label');
+        const value = node.runs.find(r => r.role === 'value');
+        return [{
+          text: [
+            { text: (label ? label.text : '') + ' ', bold: true },
+            { text: value ? value.text : '' }
+          ],
+          color: this.getColor('text.secondary'),
+          fontSize: this.getTypography('fontSize.small'),
+          margin: [0, 0, 0, 3]
+        }];
+      }
+
+      case 'careerDescription':
+        return [{
+          text: node.text,
+          color: this.getColor('text.secondary'),
+          margin: [0, 0, 0, 3]
+        }];
+
+      case 'careerNote':
+        return [{
+          text: node.text,
+          fontSize: this.getTypography('fontSize.small'),
+          italics: true,
+          color: this.getColor('text.muted'),
+          margin: [0, 3, 0, 5]
+        }];
+
+      case 'careerLeaveReason': {
+        const label = node.runs.find(r => r.role === 'label');
+        const value = node.runs.find(r => r.role === 'value');
+        return [{
+          text: [
+            { text: (label ? label.text : '') + ' ', bold: true },
+            { text: value ? value.text : '' }
+          ],
+          color: this.getColor('text.muted'),
+          fontSize: this.getTypography('fontSize.tiny'),
+          margin: [0, 0, 0, 3]
+        }];
+      }
+
+      // ── Education ─────────────────────────────────────────────────
+      case 'eduHeader': {
+        const title = node.runs.find(r => r.role === 'title');
+        const meta = node.runs.find(r => r.role === 'meta');
+        return [{
+          columns: [
+            {
+              text: title ? title.text : '',
+              fontSize: this.getTypography('fontSize.h3'),
+              bold: true,
+              color: this.getColor('primary'),
+              width: '*'
+            },
+            {
+              text: meta ? meta.text : '',
+              alignment: 'right',
+              color: this.getColor('primary'),
+              fontSize: this.getTypography('fontSize.small'),
+              bold: true,
+              width: 'auto'
+            }
+          ],
+          margin: [0, 8, 0, 4]
+        }];
+      }
+
+      case 'eduDegree':
+        return [{
+          text: node.text,
+          color: this.getColor('text.primary'),
+          fontSize: this.getTypography('fontSize.body'),
+          margin: [0, 0, 0, 3]
+        }];
+
+      case 'eduLocation':
+        return [{
+          text: node.text,
+          color: this.getColor('text.muted'),
+          italics: true,
+          fontSize: this.getTypography('fontSize.small'),
+          margin: [0, 0, 0, 3]
+        }];
+
+      // ── Compensation (private) ────────────────────────────────────
+      case 'compSubtitle':
+        return [{
+          text: node.text,
+          italics: true,
+          color: this.getColor('text.muted'),
+          fontSize: this.getTypography('fontSize.body'),
+          margin: [0, 0, 0, 6]
+        }];
+
+      case 'compIntro':
+        return [{
+          text: node.text,
+          color: this.getColor('text.primary'),
+          fontSize: this.getTypography('fontSize.small'),
+          margin: [0, 0, 0, 10]
+        }];
+
+      case 'compWarning':
+        // Confidentiality watermark line
+        return [{
+          text: node.text,
+          color: '#b91c1c',
+          bold: true,
+          fontSize: this.getTypography('fontSize.small'),
+          margin: [0, 0, 0, 10]
+        }];
+
+      case 'compBlockTitle':
+        return [{
+          text: node.text,
+          bold: true,
+          color: this.getColor('primary'),
+          fontSize: this.getTypography('fontSize.h3'),
+          margin: [0, node.variant === 'package' ? 0 : 12, 0, 4]
+        }];
+
+      case 'compEstimate':
+        return [{
+          text: node.text,
+          italics: true,
+          color: this.getColor('text.muted'),
+          fontSize: this.getTypography('fontSize.small'),
+          margin: [0, 4, 0, 12]
+        }];
+
+      case 'compStance':
+        return [{
+          text: node.text,
+          fontSize: this.getTypography('fontSize.small'),
+          color: this.getColor('text.primary'),
+          margin: [0, 0, 0, 8]
+        }];
+
+      case 'compLastUpdated':
+        return [{
+          text: node.text,
+          italics: true,
+          color: this.getColor('text.muted'),
+          fontSize: this.getTypography('fontSize.small'),
+          alignment: 'right',
+          margin: [0, 8, 0, 0]
+        }];
+
+      // ── Testimonials ──────────────────────────────────────────────
+      case 'testimonialFeaturedTag':
+        return [{
+          text: node.text,
+          fontSize: this.getTypography('fontSize.tiny'),
+          color: '#3B82F6',  // Primary
+          bold: true,
+          margin: [0, 0, 0, 4]
+        }];
+
+      case 'testimonialQuote':
+        return [{
+          text: `"${node.text}"`,
+          italics: true,
+          fontSize: (ctx && ctx.featured)
+            ? this.getTypography('fontSize.body') + 1
+            : this.getTypography('fontSize.body'),
+          margin: [this.getSpacing('list.indent'), 0, this.getSpacing('list.indent'), 8],
+          color: '#0F172A',  // Text primary
+          lineHeight: this.getTypography('lineHeight.relaxed')
+        }];
+
+      case 'testimonialAuthor': {
+        const author = node.runs.find(r => r.role === 'author');
+        const authorRole = node.runs.find(r => r.role === 'authorRole');
+        const relation = node.runs.find(r => r.role === 'relation');
+        const authorText = [];
+        authorText.push({
+          text: author ? author.text : '',
+          bold: true,
+          color: '#3B82F6'  // Primary
+        });
+        if (authorRole) {
+          authorText.push({
+            text: ', ' + authorRole.text,
+            color: '#475569',  // Text secondary
+            bold: false
+          });
+        }
+        if (relation) {
+          authorText.push({
+            text: ` (${relation.text})`,
+            color: '#3B82F6',  // Primary
+            italics: true
+          });
+        }
+        return [{
+          text: authorText,
+          fontSize: this.getTypography('fontSize.small'),
+          margin: [this.getSpacing('list.indent'), 0, 0, 0]
+        }];
+      }
+
+      // ── Manager / leadership ──────────────────────────────────────
+      case 'pmCapTitle':
+        return [{
+          text: [
+            { text: '◆ ', color: this.getColor('accent'), fontSize: 12, bold: true },
+            { text: node.text, color: this.getColor('primary'), bold: true, fontSize: 12 }
+          ],
+          margin: [0, node.first ? 0 : 10, 0, 4]
+        }];
+
+      case 'pmCapDescription':
+        return [{
+          text: node.text,
+          color: this.getColor('text.secondary'),
+          italics: true,
+          fontSize: 10.5,
+          lineHeight: 1.5,
+          margin: [16, 0, 0, 6]
+        }];
+
+      default:
+        return [];
     }
-
-    // Executive summary — 3-line P&L / team-size / impact synthesis (HBS pattern)
-    content.push({
-      text: summaryLines.join('\n'),
-      fontSize: 10.5,
-      color: this.getColor('text.secondary'),
-      lineHeight: 1.6,
-      margin: [0, 0, 0, 30]
-    });
-
-    content.push({
-      canvas: [{ type: 'line', x1: 0, y1: 0, x2: 451, y2: 0, lineWidth: 0.5, lineColor: this.getColor('border') }],
-      margin: [0, 0, 0, 26]
-    });
-
-    const stats = this.buildStatsInfographic(data);
-    if (stats) content.push(stats);
-
-    if (data.expertise?.certifications?.length > 0) {
-      const certText = data.expertise.certifications.map(c => this.getText(c.name)).join('  ·  ');
-      content.push({
-        text: lang === 'ko' ? '인증 / Certifications' : 'Certifications',
-        fontSize: 9,
-        color: this.getColor('text.muted'),
-        bold: true,
-        margin: [0, 28, 0, 6]
-      });
-      content.push({
-        text: certText,
-        fontSize: 11,
-        color: this.getColor('success'),
-        bold: true,
-        margin: [0, 0, 0, 0]
-      });
-    }
-
-    content.push({
-      text: dateStr,
-      fontSize: 9,
-      color: this.getColor('text.muted'),
-      alignment: 'right',
-      margin: [0, 60, 0, 0]
-    });
-
-    // No trailing pageBreak: 'after' here — the next section header
-    // already carries pageBreak: 'before', so adding both produces a blank page.
-    return content;
   }
 
   /**
-   * Build a 4-column stats infographic for the cover page
-   * @param {Object} data - Portfolio data
-   * @returns {Object|null} pdfmake table node or null when no data
+   * Render an IR bullet list node (role decides marker color and margins)
    */
-  buildStatsInfographic(data) {
-    const lang = this.currentLang;
-    const kn = data?.manager?.businessImpact?.keyNumbers || {};
-    const certCount = data?.expertise?.certifications?.length || kn.certifications;
-    const stats = [];
+  renderBulletListNode(node) {
+    const texts = (node.items || []).map(item => item.text);
 
-    stats.push({ value: '20+', label: lang === 'ko' ? '경력 (년)' : 'Years' });
-    if (certCount) stats.push({ value: String(certCount), label: lang === 'ko' ? '글로벌 인증' : 'Certifications' });
-    if (kn.ipos) stats.push({ value: String(kn.ipos), label: 'IPO' });
-    if (kn.performanceImprovement) stats.push({ value: String(kn.performanceImprovement), label: lang === 'ko' ? '성능 향상' : 'Performance' });
-    if (kn.projectsDelivered && stats.length < 4) {
-      stats.push({ value: String(kn.projectsDelivered), label: lang === 'ko' ? '프로젝트' : 'Projects' });
+    switch (node.role) {
+      case 'expertiseItems':
+        return [this.buildBulletList(texts)];
+
+      case 'projectDetail': {
+        const markerByVariant = {
+          roles: this.getColor('accent'),
+          challenges: this.getColor('warning'),
+          solutions: this.getColor('accent'),
+          achievements: this.getColor('success')
+        };
+        return [this.buildBulletList(texts, {
+          markerColor: markerByVariant[node.variant] || this.getColor('accent'),
+          bottomMargin: 6
+        })];
+      }
+
+      case 'careerAchievements':
+        return [this.buildBulletList(texts, { markerColor: this.getColor('success'), bottomMargin: 6 })];
+
+      case 'pmCapHighlights':
+        return [this.buildBulletList(texts, { markerColor: this.getColor('accent'), bottomMargin: 6 })];
+
+      case 'managerPrinciples':
+        return [this.buildBulletList(texts, { markerColor: this.getColor('accent') })];
+
+      case 'managerImpact':
+        return [this.buildBulletList(texts, { markerColor: this.getColor('success') })];
+
+      case 'clKeyPoints': {
+        const keyPointsContent = (node.items || []).map(item => ({
+          text: (item.runs || []).map(r => r.role === 'strong'
+            ? { text: r.text, bold: true, color: this.getColor('primary') }
+            : r.text),
+          margin: [0, 0, 0, this.getSpacing('list.itemGap') * 1.2]
+        }));
+        return [{
+          ul: keyPointsContent,
+          margin: [0, 0, 0, this.getSpacing('section.gap') * 1.5]
+        }];
+      }
+
+      case 'compNonNegotiables':
+        return texts.map(text => ({
+          text: `• ${text}`,
+          fontSize: this.getTypography('fontSize.small'),
+          color: this.getColor('text.primary'),
+          margin: [0, 0, 0, 2]
+        }));
+
+      default:
+        return [];
     }
+  }
 
-    const finalStats = stats.slice(0, 4);
-    if (finalStats.length === 0) return null;
+  /**
+   * Render an IR key/value list
+   */
+  renderKeyValueList(node) {
+    const entries = node.entries || [];
+
+    switch (node.role) {
+      case 'heroCapabilities':
+        return entries.map(entry => ({
+          text: [
+            { text: entry.label + ': ', bold: true },
+            { text: entry.value }
+          ],
+          margin: [this.getSpacing('list.indent'), 0, 0, 5]
+        }));
+
+      case 'careerScale':
+        return [{
+          text: entries.map(entry => `${entry.label} ${entry.value}`).join('  |  '),
+          color: this.getColor('text.muted'),
+          fontSize: this.getTypography('fontSize.tiny'),
+          margin: [0, 0, 0, 3]
+        }];
+
+      case 'compComponents':
+        return entries.map(entry => ({
+          text: `• ${entry.label}: ${entry.value}`,
+          fontSize: this.getTypography('fontSize.small'),
+          color: this.getColor('text.primary'),
+          margin: [0, 0, 0, 2]
+        }));
+
+      case 'compRationales':
+        // Per-tier rationale lines
+        return entries.map(entry => ({
+          text: [
+            { text: `${entry.label}: `, bold: true, color: this.getColor('primary') },
+            { text: entry.value, color: this.getColor('text.muted') }
+          ],
+          fontSize: this.getTypography('fontSize.small'),
+          margin: [0, 0, 0, 3]
+        }));
+
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * Render an IR badge row. The joiner and bracket decoration are PDF
+   * styling decisions (the DOCX walker uses its own).
+   */
+  renderBadgeRow(node) {
+    const items = node.items || [];
+
+    switch (node.role) {
+      case 'expertiseTags':
+        return [{
+          text: '[ ' + items.join(' | ') + ' ]',
+          fontSize: this.getTypography('fontSize.small') + 1,  // Slightly larger
+          color: '#3B82F6',  // Primary blue matching web
+          bold: true,
+          margin: [this.getSpacing('list.indent'), 0, 0, this.getSpacing('list.marginBottom')]
+        }];
+
+      case 'certificationBadges':
+        return [{
+          text: items.join(' | '),
+          color: this.getColor('success'),  // Success green matching web
+          bold: true,
+          fontSize: this.getTypography('fontSize.body') + 1,
+          margin: [this.getSpacing('list.indent'), 0, 0, 10]
+        }];
+
+      case 'projectTags':
+        return [{
+          text: '[ ' + items.join(' | ') + ' ]',
+          fontSize: this.getTypography('fontSize.tiny') + 1,  // Slightly larger for readability
+          color: '#3B82F6',  // Primary blue matching web accent
+          bold: true,
+          margin: [0, 0, 0, 8]
+        }];
+
+      case 'careerTags':
+        return [{
+          text: items.join(' | '),
+          color: this.getColor('primary'),
+          fontSize: this.getTypography('fontSize.tiny'),
+          margin: [0, 0, 0, 5]
+        }];
+
+      case 'testimonialLabels':
+        return [{
+          text: '[ ' + items.join(' | ') + ' ]',
+          fontSize: this.getTypography('fontSize.tiny'),
+          color: '#10B981',  // Success
+          bold: true,
+          margin: [this.getSpacing('list.indent'), 5, 0, 0]
+        }];
+
+      case 'pmCapMetrics':
+        return [{
+          text: items.join('   ·   '),
+          color: this.getColor('accent'),
+          bold: true,
+          fontSize: 9,
+          margin: [16, 4, 0, 0]
+        }];
+
+      case 'pmCapTags':
+        return [{
+          text: items.join(' · '),
+          color: this.getColor('text.muted'),
+          fontSize: 9,
+          margin: [16, 4, 0, 0]
+        }];
+
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * Render an IR table node
+   */
+  renderTable(node) {
+    switch (node.role) {
+      case 'compTiers': {
+        // Negotiation tiers as a compact table
+        const headerRow = (node.header || []).map(h => ({ text: h, bold: true }));
+        const body = [headerRow];
+        (node.rows || []).forEach(rowData => {
+          body.push(rowData.map((val, idx) => idx === 0
+            ? { text: val, bold: true }
+            : { text: val }));
+        });
+        return [{
+          table: {
+            headerRows: 1,
+            widths: ['auto', '*', '*', '*', '*', '*'],
+            body
+          },
+          layout: 'lightHorizontalLines',
+          fontSize: this.getTypography('fontSize.small'),
+          margin: [0, 0, 0, 10]
+        }];
+      }
+
+      case 'softSkillsGrid': {
+        // 2-column descriptive grid
+        const buildSkillCell = (skill) => ({
+          stack: [
+            {
+              text: [
+                { text: '◆  ', color: this.getColor('accent'), fontSize: 11, bold: true },
+                { text: skill.title, color: this.getColor('primary'), bold: true, fontSize: 11.5 }
+              ],
+              margin: [0, 0, 0, 5]
+            },
+            ...(skill.description ? [{
+              text: skill.description,
+              color: this.getColor('text.secondary'),
+              fontSize: 9.5,
+              lineHeight: 1.55,
+              margin: [16, 0, 0, 0]
+            }] : [])
+          ]
+        });
+
+        const cells = (node.cells || []).map(buildSkillCell);
+        while (cells.length % 2 !== 0) cells.push({ text: '' });
+        const rows = [];
+        for (let i = 0; i < cells.length; i += 2) rows.push(cells.slice(i, i + 2));
+
+        return [{
+          table: { widths: ['*', '*'], body: rows },
+          layout: {
+            hLineWidth: () => 0,
+            vLineWidth: () => 0,
+            paddingLeft: () => 10,
+            paddingRight: () => 10,
+            paddingTop: () => 10,
+            paddingBottom: () => 12
+          },
+          margin: [0, 0, 0, 6]
+        }];
+      }
+
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * Render the cover-page stats row as a 2-row infographic table
+   */
+  renderStatsRow(node) {
+    const finalStats = node.items || [];
+    if (finalStats.length === 0) return [];
 
     const widths = Array(finalStats.length).fill('*');
     const valueRow = finalStats.map(s => ({
@@ -946,7 +1553,7 @@ class PDFExporter {
       margin: [0, 8, 0, 12]
     }));
 
-    return {
+    return [{
       table: { widths, heights: [56, 28], body: [valueRow, labelRow] },
       layout: {
         hLineWidth: () => 0,
@@ -958,7 +1565,85 @@ class PDFExporter {
         paddingBottom: () => 0
       },
       margin: [0, 0, 0, 0]
-    };
+    }];
+  }
+
+  /**
+   * Render decorative spacers/rules (role decides the exact visual)
+   */
+  renderSpacer(node) {
+    switch (node.role) {
+      case 'coverTopRule':
+        return [{
+          canvas: [{ type: 'rect', x: 0, y: 0, w: 60, h: 3, color: this.getColor('primary') }],
+          margin: [0, 40, 0, 48]
+        }];
+
+      case 'coverDivider':
+        return [{
+          canvas: [{ type: 'line', x1: 0, y1: 0, x2: 451, y2: 0, lineWidth: 0.5, lineColor: this.getColor('border') }],
+          margin: [0, 0, 0, 26]
+        }];
+
+      case 'inlineHeaderRule': {
+        // Header underline depends on the theme's headerStyle layout key
+        const headerStyle = this.getLayout('headerStyle');
+        if (headerStyle === 'underlined' || headerStyle === 'bordered') {
+          return [{
+            canvas: [{
+              type: 'line',
+              x1: 0, y1: 0,
+              x2: 451, y2: 0,
+              lineWidth: 3,
+              lineColor: this.getColor('primary')
+            }],
+            margin: [0, this.getSpacing('header.paddingBottom'), 0, this.getSpacing('section.marginTop')]
+          }];
+        } else if (headerStyle === 'boxed') {
+          return [{
+            canvas: [{
+              type: 'rect',
+              x: 0, y: -50,
+              w: 451, h: 80,
+              lineWidth: 1,
+              lineColor: '#E2E8F0'
+            }],
+            margin: [0, 0, 0, this.getSpacing('section.marginBottom')]
+          }];
+        }
+        // Default: simple spacing
+        return [{
+          text: '',
+          margin: [0, 0, 0, this.getSpacing('section.marginTop')]
+        }];
+      }
+
+      case 'projectDetailRule':
+        // Separator between project summary and expanded details
+        return [{
+          canvas: [{
+            type: 'line',
+            x1: 0, y1: 0,
+            x2: 150, y2: 0,
+            lineWidth: 1,
+            lineColor: '#E2E8F0'
+          }],
+          margin: [0, 8, 0, 8]
+        }];
+
+      case 'testimonialDivider':
+        // Thin centered rule between adjacent testimonials
+        return [{
+          canvas: [{ type: 'line', x1: 200, y1: 0, x2: 315, y2: 0, lineWidth: 0.5, lineColor: this.getColor('border') }],
+          margin: [0, 4, 0, 6]
+        }];
+
+      case 'pmCapabilitiesEnd':
+        return [{ text: '', margin: [0, 0, 0, 10] }];
+
+      default:
+        return [];
+    }
   }
 
   /**
@@ -996,86 +1681,6 @@ class PDFExporter {
     };
   }
 
-  /**
-   * Build document header with enhanced styling
-   */
-  buildHeader(info) {
-    const headerStyle = this.getLayout('headerStyle');
-    const locale = this.currentLang === 'ko' ? 'ko-KR' : 'en-US';
-
-    // Enhanced header with better typography
-    const headerContent = {
-      columns: [
-        {
-          text: info.author || info.title,
-          fontSize: this.getTypography('fontSize.h1'),
-          bold: true,
-          color: this.getColor('primary')  // Use primary color directly instead of style
-        },
-        {
-          text: new Date().toLocaleDateString(locale, {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric'
-          }),
-          alignment: 'right',
-          fontSize: this.getTypography('fontSize.small'),
-          color: this.getColor('text.muted'),
-          margin: [0, 8, 0, 0],
-          width: 'auto'
-        }
-      ],
-      margin: [0, 0, 0, this.getSpacing('header.marginBottom')]
-    };
-
-    // Apply header style with gradient-like effect
-    if (headerStyle === 'underlined' || headerStyle === 'bordered') {
-      return [
-        headerContent,
-        {
-          canvas: [{
-            type: 'line',
-            x1: 0, y1: 0,
-            x2: 451, y2: 0,
-            lineWidth: 3,
-            lineColor: this.getColor('primary')
-          }],
-          margin: [0, this.getSpacing('header.paddingBottom'), 0, this.getSpacing('section.marginTop')]
-        }
-      ];
-    } else if (headerStyle === 'boxed') {
-      return [
-        headerContent,
-        {
-          canvas: [{
-            type: 'rect',
-            x: 0, y: -50,
-            w: 451, h: 80,
-            lineWidth: 1,
-            lineColor: '#E2E8F0'
-          }],
-          margin: [0, 0, 0, this.getSpacing('section.marginBottom')]
-        }
-      ];
-    }
-
-    // Default: simple header with spacing
-    return [
-      headerContent,
-      {
-        text: '',
-        margin: [0, 0, 0, this.getSpacing('section.marginTop')]
-      }
-    ];
-  }
-
-  /**
-   * Build a card-style section header with optional page break.
-   * Returns nodes ready to push into pdfmake content (header + spacer).
-   * @param {string} text - Section title (uppercase recommended)
-   * @param {boolean} addPageBreak - Force page break before this section
-   * @returns {Array} pdfmake content nodes
-   */
   /**
    * Render a bullet list as a stack of paragraphs that mirrors the DOCX
    * '·  ' style — colored leading marker + indented body text. This keeps
@@ -1141,6 +1746,13 @@ class PDFExporter {
     ];
   }
 
+  /**
+   * Build a card-style section header with optional page break.
+   * Returns nodes ready to push into pdfmake content (header + rule).
+   * @param {string} text - Section title (uppercase applied)
+   * @param {boolean} addPageBreak - Force page break before this section
+   * @returns {Array} pdfmake content nodes
+   */
   buildSectionHeader(text, addPageBreak = false) {
     // Single full-width primary-color rule under the heading,
     // matching the DOCX H2 paragraph bottom border (1.5pt primary).
@@ -1161,995 +1773,6 @@ class PDFExporter {
         margin: [0, 0, 0, 18]
       }
     ];
-  }
-
-  /**
-   * Build expertise section
-   * @param {Object} expertise - Expertise data
-   * @param {boolean} addPageBreak - Whether to add page break before section
-   */
-  buildExpertiseSection(expertise, addPageBreak = false) {
-    const content = [];
-    const labels = this.getLabels();
-
-    content.push(...this.buildSectionHeader(labels.expertise, addPageBreak));
-
-    // Categories with color-coded sections
-    if (expertise.categories && expertise.categories.length > 0) {
-      expertise.categories.forEach((category, index) => {
-        const categoryContent = [];
-
-        // Category title with enhanced primary color (style removed to allow color override)
-        categoryContent.push({
-          text: '[ ' + this.getText(category.title) + ' ]',
-          fontSize: this.getTypography('fontSize.h3'),
-          color: '#3B82F6',  // Primary blue matching web design
-          bold: true,
-          margin: [0, this.getSpacing('subsection.marginTop'), 0, this.getSpacing('subsection.marginBottom')]
-        });
-
-        const items = this.getArray(category.items);
-        if (items.length > 0) {
-          categoryContent.push(this.buildBulletList(
-            items.map(item => this.stripHtml(this.getText(item)))
-          ));
-        }
-
-        // Handle tags for Technologies category with web-like styling
-        const tags = this.getArray(category.tags);
-        if (tags.length > 0) {
-          categoryContent.push({
-            text: '[ ' + tags.map(tag => this.getText(tag)).join(' | ') + ' ]',
-            fontSize: this.getTypography('fontSize.small') + 1,  // Slightly larger
-            color: '#3B82F6',  // Primary blue matching web
-            bold: true,
-            margin: [this.getSpacing('list.indent'), 0, 0, this.getSpacing('list.marginBottom')]
-          });
-        }
-
-        content.push({
-          unbreakable: true,
-          stack: categoryContent,
-          margin: [0, 0, 0, this.getSpacing('gap.medium')]
-        });
-      });
-    }
-
-    // Hero Capabilities
-    if (expertise.heroCapabilities && expertise.heroCapabilities.length > 0) {
-      const capabilitiesContent = [];
-
-      capabilitiesContent.push({
-        text: labels.coreCapabilities,
-        style: 'sectionTitle'
-      });
-
-      expertise.heroCapabilities.forEach(cap => {
-        capabilitiesContent.push({
-          text: [
-            { text: this.getText(cap.title) + ': ', bold: true },
-            { text: this.getText(cap.description) }
-          ],
-          margin: [this.getSpacing('list.indent'), 0, 0, 5]
-        });
-      });
-
-      content.push({
-        unbreakable: true,
-        stack: capabilitiesContent,
-        margin: [0, 0, 0, 5]
-      });
-    }
-
-    // Certifications with enhanced web-like styling
-    if (expertise.certifications && expertise.certifications.length > 0) {
-      content.push({
-        unbreakable: true,
-        stack: [
-          {
-            text: labels.certifications,
-            fontSize: this.getTypography('fontSize.h3'),
-            color: '#3B82F6',  // Primary blue
-            bold: true,
-            margin: [0, 18, 0, 8]
-          },
-          {
-            text: expertise.certifications.map(cert => this.getText(cert.name)).join(' | '),
-            color: this.getColor('success'),  // Success green matching web
-            bold: true,
-            fontSize: this.getTypography('fontSize.body') + 1,
-            margin: [this.getSpacing('list.indent'), 0, 0, 10]
-          }
-        ],
-        margin: [0, 0, 0, 5]
-      });
-    }
-
-    return content;
-  }
-
-  /**
-   * Strip HTML tags from text
-   */
-  stripHtml(html) {
-    if (!html) return '';
-    return html.replace(/<[^>]*>/g, '');
-  }
-
-  /**
-   * Build projects section
-   * @param {Object} projects - Projects data
-   * @param {boolean} addPageBreak - Whether to add page break before section
-   */
-  buildProjectsSection(projects, addPageBreak = false) {
-    const content = [];
-    const labels = this.getLabels();
-
-    content.push(...this.buildSectionHeader(labels.projects, addPageBreak));
-
-    // Each category that has projects starts on a new page for readability.
-    // The very first category sits on the same page as the PROJECTS header.
-    let firstCategory = true;
-
-    if (projects.featured && projects.featured.length > 0) {
-      content.push(...this.buildSubsectionHeader(labels.featuredProjects, !firstCategory));
-      firstCategory = false;
-      projects.featured.forEach(project => {
-        content.push(this.formatProject(project));
-      });
-    }
-
-    const categories = ['medicalImaging', 'orthodontic', 'equipmentControl', 'enterprise', 'openSource'];
-    categories.forEach(category => {
-      if (projects[category] && projects[category].length > 0) {
-        const categoryName = this.formatCategoryName(category);
-        content.push(...this.buildSubsectionHeader(categoryName, !firstCategory));
-        firstCategory = false;
-        projects[category].forEach(project => {
-          content.push(this.formatProject(project));
-        });
-      }
-    });
-
-    return content;
-  }
-
-  /**
-   * Format a single project with enhanced color coding
-   */
-  formatProject(project) {
-    const items = [];
-    const labels = this.getLabels();
-
-    // Project title with primary color for emphasis
-    items.push({
-      text: this.getText(project.title) || this.getText(project.name) || 'Untitled Project',
-      bold: true,
-      fontSize: this.getTypography('fontSize.h3'),
-      color: this.getColor('primary'),  // Changed to primary for emphasis
-      margin: [0, 0, 0, 4],
-      lineHeight: this.getTypography('lineHeight.tight')
-    });
-
-    // Company and period with distinct colors
-    if (project.company || project.period) {
-      const metaText = [];
-      if (project.company) {
-        metaText.push({
-          text: this.getText(project.company),
-          color: this.getColor('text.secondary'),
-          bold: true
-        });
-      }
-      if (project.period) {
-        const period = this.formatPeriodWithDuration(project.period);
-        if (project.company) {
-          metaText.push({ text: ' | ', color: this.getColor('text.muted') });
-        }
-        metaText.push({
-          text: period,
-          color: this.getColor('accent')  // Accent color for dates
-        });
-      }
-
-      items.push({
-        text: metaText,
-        fontSize: this.getTypography('fontSize.small'),
-        italics: true,
-        margin: [0, 0, 0, 6]
-      });
-    }
-
-    // Description with better spacing
-    if (project.description) {
-      items.push({
-        text: this.stripHtml(this.getText(project.description)),
-        color: this.getColor('text.secondary'),
-        fontSize: this.getTypography('fontSize.body'),
-        lineHeight: this.getTypography('lineHeight.relaxed'),
-        margin: [0, 0, 0, 8]
-      });
-    }
-
-    // Tags with enhanced web-like styling
-    const tags = this.getArray(project.tags);
-    if (tags.length > 0) {
-      items.push({
-        text: '[ ' + tags.map(tag => this.getText(tag)).join(' | ') + ' ]',
-        fontSize: this.getTypography('fontSize.tiny') + 1,  // Slightly larger for readability
-        color: '#3B82F6',  // Primary blue matching web accent
-        bold: true,
-        margin: [0, 0, 0, 8]
-      });
-    }
-
-    // Expanded details with color-coded sections
-    if (project.expanded) {
-      const roles = this.getArray(project.expanded.roles);
-      if (roles.length > 0) {
-        // Add a separator line
-        items.push({
-          canvas: [{
-            type: 'line',
-            x1: 0, y1: 0,
-            x2: 150, y2: 0,
-            lineWidth: 1,
-            lineColor: '#E2E8F0'
-          }],
-          margin: [0, 8, 0, 8]
-        });
-
-        items.push({
-          text: '[ ' + labels.keyResponsibilities + ' ]',
-          bold: true,
-          fontSize: this.getTypography('fontSize.h4'),
-          color: '#3B82F6',  // Primary color
-          margin: [0, 0, 0, 4]
-        });
-        items.push(this.buildBulletList(
-          roles.map(r => this.stripHtml(this.getText(r))),
-          { markerColor: this.getColor('accent'), bottomMargin: 6 }
-        ));
-      }
-
-      // Challenges / solutions mirror the public site's expanded project
-      // card (components.js) so exported documents carry the same content.
-      const challenges = this.getArray(project.expanded.challenges);
-      if (challenges.length > 0) {
-        items.push({
-          text: '[ ' + labels.challenges + ' ]',
-          bold: true,
-          fontSize: this.getTypography('fontSize.h4'),
-          color: '#F59E0B',  // Warning color
-          margin: [0, 6, 0, 4]
-        });
-        items.push(this.buildBulletList(
-          challenges.map(c => this.stripHtml(this.getText(c))),
-          { markerColor: this.getColor('warning'), bottomMargin: 6 }
-        ));
-      }
-
-      const solutions = this.getArray(project.expanded.solutions);
-      if (solutions.length > 0) {
-        items.push({
-          text: '[ ' + labels.solutions + ' ]',
-          bold: true,
-          fontSize: this.getTypography('fontSize.h4'),
-          color: '#3B82F6',  // Primary color
-          margin: [0, 6, 0, 4]
-        });
-        items.push(this.buildBulletList(
-          solutions.map(s => this.stripHtml(this.getText(s))),
-          { markerColor: this.getColor('accent'), bottomMargin: 6 }
-        ));
-      }
-
-      const achievements = this.getArray(project.expanded.achievements);
-      if (achievements.length > 0) {
-        items.push({
-          text: '[ ' + labels.achievements + ' ]',
-          bold: true,
-          fontSize: this.getTypography('fontSize.h4'),
-          color: '#10B981',  // Success color
-          margin: [0, 6, 0, 4]
-        });
-        items.push(this.buildBulletList(
-          achievements.map(a => this.stripHtml(this.getText(a))),
-          { markerColor: this.getColor('success'), bottomMargin: 6 }
-        ));
-      }
-    }
-
-    // Return with card-like styling. Bottom margin sized to keep projects
-    // distinct without leaving large gaps on the page.
-    return {
-      unbreakable: true,
-      stack: items,
-      margin: [0, 0, 0, 22]
-    };
-  }
-
-  /**
-   * Build career section
-   * @param {Object} career - Career data
-   * @param {boolean} addPageBreak - Whether to add page break before section
-   */
-  buildCareerSection(career, addPageBreak = false) {
-    const content = [];
-    const labels = this.getLabels();
-
-    content.push(...this.buildSectionHeader(labels.career, addPageBreak));
-
-    if (career.timeline && career.timeline.length > 0) {
-      career.timeline.forEach(item => {
-        const entry = [];
-
-        // Company with optional badge
-        const companyText = [];
-        companyText.push({
-          text: this.getText(item.company) || this.getText(item.title) || '',
-          bold: true,
-          color: '#3B82F6'  // Primary color
-        });
-        if (item.badge) {
-          companyText.push({
-            text: ' [' + this.getText(item.badge) + ']',
-            color: '#F59E0B',  // Warning color
-            bold: true
-          });
-        }
-
-        entry.push({
-          columns: [
-            {
-              text: companyText,
-              fontSize: this.getTypography('fontSize.h3'),
-              width: '*'
-            },
-            {
-              text: this.formatPeriodWithDuration(item.period) || '',
-              alignment: 'right',
-              color: '#3B82F6',  // Primary color for dates
-              fontSize: this.getTypography('fontSize.small'),
-              bold: true,
-              width: 'auto'
-            }
-          ],
-          margin: [0, 8, 0, 4]
-        });
-
-        if (item.role || item.position) {
-          entry.push({
-            text: '> ' + (this.getText(item.role) || this.getText(item.position)),
-            color: '#0F172A',  // Text primary
-            fontSize: this.getTypography('fontSize.body'),
-            bold: true,
-            margin: [0, 0, 0, 4]
-          });
-        }
-
-        // Company description
-        if (item.companyDescription) {
-          entry.push({
-            text: this.stripHtml(this.getText(item.companyDescription)),
-            italics: true,
-            color: this.getColor('text.muted'),
-            fontSize: this.getTypography('fontSize.small'),
-            margin: [0, 0, 0, 3]
-          });
-        }
-
-        // Responsibilities
-        if (item.responsibilities) {
-          entry.push({
-            text: [
-              { text: labels.responsibilities + ' ', bold: true },
-              { text: this.stripHtml(this.getText(item.responsibilities)) }
-            ],
-            color: this.getColor('text.secondary'),
-            fontSize: this.getTypography('fontSize.small'),
-            margin: [0, 0, 0, 3]
-          });
-        }
-
-        // Scale (company/team size)
-        if (item.scale && (item.scale.company || item.scale.team)) {
-          const scaleText = [];
-          if (item.scale.company) {
-            scaleText.push(`${labels.companyScale} ${this.getText(item.scale.company)}`);
-          }
-          if (item.scale.team) {
-            scaleText.push(`${labels.teamScale} ${this.getText(item.scale.team)}`);
-          }
-          entry.push({
-            text: scaleText.join('  |  '),
-            color: this.getColor('text.muted'),
-            fontSize: this.getTypography('fontSize.tiny'),
-            margin: [0, 0, 0, 3]
-          });
-        }
-
-        if (item.description) {
-          entry.push({
-            text: this.stripHtml(this.getText(item.description)),
-            color: this.getColor('text.secondary'),
-            margin: [0, 0, 0, 3]
-          });
-        }
-
-        const achievements = this.getArray(item.achievements);
-        if (achievements.length > 0) {
-          // Add achievements label with success color
-          entry.push({
-            text: '[ ' + labels.keyAchievements + ' ]',
-            bold: true,
-            fontSize: this.getTypography('fontSize.h4'),
-            color: '#10B981',  // Success color
-            margin: [0, 6, 0, 3]
-          });
-          entry.push(this.buildBulletList(
-            achievements.map(a => this.stripHtml(this.getText(a))),
-            { markerColor: this.getColor('success'), bottomMargin: 6 }
-          ));
-        }
-
-        if (item.note) {
-          entry.push({
-            text: this.stripHtml(this.getText(item.note)),
-            fontSize: this.getTypography('fontSize.small'),
-            italics: true,
-            color: this.getColor('text.muted'),
-            margin: [0, 3, 0, 5]
-          });
-        }
-
-        // Leave reason
-        if (item.leaveReason) {
-          entry.push({
-            text: [
-              { text: labels.reasonForLeaving + ' ', bold: true },
-              { text: this.stripHtml(this.getText(item.leaveReason)) }
-            ],
-            color: this.getColor('text.muted'),
-            fontSize: this.getTypography('fontSize.tiny'),
-            margin: [0, 0, 0, 3]
-          });
-        }
-
-        const tags = this.getArray(item.tags);
-        if (tags.length > 0) {
-          entry.push({
-            text: tags.map(tag => this.getText(tag)).join(' | '),
-            color: this.getColor('primary'),
-            fontSize: this.getTypography('fontSize.tiny'),
-            margin: [0, 0, 0, 5]
-          });
-        }
-
-        content.push({
-          unbreakable: true,
-          stack: entry,
-          margin: [0, 0, 0, this.getSpacing('gap.xlarge')]
-        });
-      });
-    }
-
-    return content;
-  }
-
-  /**
-   * Build education section
-   * @param {Object} education - Education data ({ items: [] })
-   * @param {boolean} addPageBreak - Whether to add page break before section
-   */
-  buildEducationSection(education, addPageBreak = false) {
-    const content = [];
-    const labels = this.getLabels();
-    content.push(...this.buildSectionHeader(labels.education, addPageBreak));
-
-    const items = education?.items || [];
-    items.forEach(item => {
-      const entry = [];
-
-      entry.push({
-        columns: [
-          {
-            text: this.getText(item.institution) || '',
-            fontSize: this.getTypography('fontSize.h3'),
-            bold: true,
-            color: this.getColor('primary'),
-            width: '*'
-          },
-          {
-            text: item.period || '',
-            alignment: 'right',
-            color: this.getColor('primary'),
-            fontSize: this.getTypography('fontSize.small'),
-            bold: true,
-            width: 'auto'
-          }
-        ],
-        margin: [0, 8, 0, 4]
-      });
-
-      if (item.degree) {
-        entry.push({
-          text: this.getText(item.degree),
-          color: this.getColor('text.primary'),
-          fontSize: this.getTypography('fontSize.body'),
-          margin: [0, 0, 0, 3]
-        });
-      }
-
-      if (item.location) {
-        entry.push({
-          text: this.getText(item.location),
-          color: this.getColor('text.muted'),
-          italics: true,
-          fontSize: this.getTypography('fontSize.small'),
-          margin: [0, 0, 0, 3]
-        });
-      }
-
-      content.push({
-        unbreakable: true,
-        stack: entry,
-        margin: [0, 0, 0, this.getSpacing('gap.medium')]
-      });
-    });
-
-    return content;
-  }
-
-  /**
-   * Build compensation section (PRIVATE).
-   * Renders the expected compensation tiers as a compact table. Only included
-   * in exports when the user explicitly enables the option in the export modal.
-   * @param {Object} compensation - Compensation data
-   * @param {boolean} addPageBreak - Whether to add page break before section
-   */
-  buildCompensationSection(compensation, addPageBreak = false) {
-    const content = [];
-    const labels = this.getLabels();
-
-    content.push(...this.buildSectionHeader(labels.compensation, addPageBreak));
-
-    if (compensation.subtitle) {
-      content.push({
-        text: this.getText(compensation.subtitle),
-        italics: true,
-        color: this.getColor('text.muted'),
-        fontSize: this.getTypography('fontSize.body'),
-        margin: [0, 0, 0, 6]
-      });
-    }
-    if (compensation.intro) {
-      content.push({
-        text: this.getText(compensation.intro),
-        color: this.getColor('text.primary'),
-        fontSize: this.getTypography('fontSize.small'),
-        margin: [0, 0, 0, 10]
-      });
-    }
-
-    // Confidentiality watermark line
-    content.push({
-      text: this.getText({
-        ko: '※ 본 섹션은 비공개 협상용 자료입니다. 외부 유출 금지.',
-        en: '※ This section is private negotiation material. Do not distribute externally.'
-      }),
-      color: '#b91c1c',
-      bold: true,
-      fontSize: this.getTypography('fontSize.small'),
-      margin: [0, 0, 0, 10]
-    });
-
-    // Current package summary
-    if (compensation.currentPackage) {
-      content.push({
-        text: this.getText(compensation.currentPackage.label) || '',
-        bold: true,
-        color: this.getColor('primary'),
-        fontSize: this.getTypography('fontSize.h3'),
-        margin: [0, 0, 0, 4]
-      });
-      const components = compensation.currentPackage.components || [];
-      components.forEach(c => {
-        content.push({
-          text: `• ${this.getText(c.label)}: ${c.value || ''}`,
-          fontSize: this.getTypography('fontSize.small'),
-          color: this.getColor('text.primary'),
-          margin: [0, 0, 0, 2]
-        });
-      });
-      if (compensation.currentPackage.estimatedAnnualEv) {
-        content.push({
-          text: this.getText(compensation.currentPackage.estimatedAnnualEv),
-          italics: true,
-          color: this.getColor('text.muted'),
-          fontSize: this.getTypography('fontSize.small'),
-          margin: [0, 4, 0, 12]
-        });
-      }
-    }
-
-    // Negotiation tiers as a 5-column table
-    const tiers = compensation.tiers || [];
-    if (tiers.length > 0) {
-      const headerRow = [
-        { text: this.getText({ ko: '시나리오', en: 'Tier' }), bold: true },
-        { text: this.getText({ ko: '기본급', en: 'Base' }), bold: true },
-        { text: this.getText({ ko: '사이닝', en: 'Signing' }), bold: true },
-        { text: this.getText({ ko: '인센티브', en: 'Incentive' }), bold: true },
-        { text: this.getText({ ko: '옵션/RSU', en: 'Options/RSU' }), bold: true },
-        { text: this.getText({ ko: '1년차 총보상', en: '1Y Total' }), bold: true }
-      ];
-      const body = [headerRow];
-      tiers.forEach(tier => {
-        body.push([
-          { text: this.getText(tier.label), bold: true },
-          { text: this.getText(tier.base) || '' },
-          { text: this.getText(tier.signing) || '' },
-          { text: this.getText(tier.incentive) || '' },
-          { text: this.getText(tier.options) || '' },
-          { text: this.getText(tier.totalFirstYear) || '' }
-        ]);
-      });
-
-      content.push({
-        table: {
-          headerRows: 1,
-          widths: ['auto', '*', '*', '*', '*', '*'],
-          body
-        },
-        layout: 'lightHorizontalLines',
-        fontSize: this.getTypography('fontSize.small'),
-        margin: [0, 0, 0, 10]
-      });
-
-      // Per-tier rationale lines
-      tiers.forEach(tier => {
-        if (tier.rationale) {
-          content.push({
-            text: [
-              { text: `${this.getText(tier.label)}: `, bold: true, color: this.getColor('primary') },
-              { text: this.getText(tier.rationale), color: this.getColor('text.muted') }
-            ],
-            fontSize: this.getTypography('fontSize.small'),
-            margin: [0, 0, 0, 3]
-          });
-        }
-      });
-    }
-
-    // Non-negotiables
-    if (Array.isArray(compensation.nonNegotiables) && compensation.nonNegotiables.length) {
-      content.push({
-        text: this.getText({ ko: '비협상 조건', en: 'Non-negotiable Terms' }),
-        bold: true,
-        color: this.getColor('primary'),
-        fontSize: this.getTypography('fontSize.h3'),
-        margin: [0, 12, 0, 4]
-      });
-      compensation.nonNegotiables.forEach(item => {
-        content.push({
-          text: `• ${this.getText(item)}`,
-          fontSize: this.getTypography('fontSize.small'),
-          color: this.getColor('text.primary'),
-          margin: [0, 0, 0, 2]
-        });
-      });
-    }
-
-    // Negotiation stance
-    if (compensation.negotiationStance) {
-      content.push({
-        text: this.getText({ ko: '협상 입장', en: 'Negotiation Stance' }),
-        bold: true,
-        color: this.getColor('primary'),
-        fontSize: this.getTypography('fontSize.h3'),
-        margin: [0, 12, 0, 4]
-      });
-      content.push({
-        text: this.getText(compensation.negotiationStance),
-        fontSize: this.getTypography('fontSize.small'),
-        color: this.getColor('text.primary'),
-        margin: [0, 0, 0, 8]
-      });
-    }
-
-    if (compensation.lastUpdated) {
-      content.push({
-        text: this.getText({ ko: `최종 갱신: ${compensation.lastUpdated}`, en: `Last updated: ${compensation.lastUpdated}` }),
-        italics: true,
-        color: this.getColor('text.muted'),
-        fontSize: this.getTypography('fontSize.small'),
-        alignment: 'right',
-        margin: [0, 8, 0, 0]
-      });
-    }
-
-    return content;
-  }
-
-  /**
-   * Build testimonials section
-   * @param {Object} testimonials - Testimonials data
-   * @param {boolean} addPageBreak - Whether to add page break before section
-   */
-  buildTestimonialsSection(testimonials, addPageBreak = false) {
-    const content = [];
-    const labels = this.getLabels();
-
-    content.push(...this.buildSectionHeader(labels.testimonials, addPageBreak));
-
-    // Build a flat list, inserting a thin centered separator rule between
-    // adjacent testimonials so each block visually closes before the next.
-    const ordered = [];
-    if (testimonials.featured) ordered.push({ t: testimonials.featured, featured: true });
-    if (testimonials.testimonials && testimonials.testimonials.length > 0) {
-      testimonials.testimonials.forEach(t => ordered.push({ t, featured: false }));
-    }
-
-    ordered.forEach(({ t, featured }, idx) => {
-      if (idx > 0) {
-        content.push({
-          canvas: [{ type: 'line', x1: 200, y1: 0, x2: 315, y2: 0, lineWidth: 0.5, lineColor: this.getColor('border') }],
-          margin: [0, 4, 0, 6]
-        });
-      }
-      content.push(this.formatTestimonial(t, featured));
-    });
-
-    return content;
-  }
-
-  /**
-   * Format a single testimonial with enhanced visual hierarchy
-   */
-  formatTestimonial(testimonial, isFeatured) {
-    const items = [];
-
-    // Add colored background box for featured testimonials
-    if (isFeatured) {
-      items.push({
-        text: isFeatured ? '[ Featured Testimonial ]' : '',
-        fontSize: this.getTypography('fontSize.tiny'),
-        color: '#3B82F6',  // Primary
-        bold: true,
-        margin: [0, 0, 0, 4]
-      });
-    }
-
-    if (testimonial.quote || testimonial.text) {
-      const quoteText = this.getText(testimonial.quote) || this.getText(testimonial.text);
-      items.push({
-        text: `"${this.stripHtml(quoteText)}"`,
-        italics: true,
-        fontSize: isFeatured ? this.getTypography('fontSize.body') + 1 : this.getTypography('fontSize.body'),
-        margin: [this.getSpacing('list.indent'), 0, this.getSpacing('list.indent'), 8],
-        color: '#0F172A',  // Text primary
-        lineHeight: this.getTypography('lineHeight.relaxed')
-      });
-    }
-
-    // Author info with color coding
-    const authorText = [];
-    authorText.push({
-      text: this.getText(testimonial.author) || this.getText(testimonial.name) || '',
-      bold: true,
-      color: '#3B82F6'  // Primary
-    });
-    if (testimonial.role) {
-      authorText.push({
-        text: ', ' + this.getText(testimonial.role),
-        color: '#475569',  // Text secondary
-        bold: false
-      });
-    }
-    if (testimonial.relation) {
-      authorText.push({
-        text: ` (${this.getText(testimonial.relation)})`,
-        color: '#3B82F6',  // Primary
-        italics: true
-      });
-    }
-
-    items.push({
-      text: authorText,
-      fontSize: this.getTypography('fontSize.small'),
-      margin: [this.getSpacing('list.indent'), 0, 0, 0]
-    });
-
-    // Labels
-    if (testimonial.labels && testimonial.labels.length > 0) {
-      items.push({
-        text: '[ ' + testimonial.labels.map(l => this.getText(l.text)).join(' | ') + ' ]',
-        fontSize: this.getTypography('fontSize.tiny'),
-        color: '#10B981',  // Success
-        bold: true,
-        margin: [this.getSpacing('list.indent'), 5, 0, 0]
-      });
-    }
-
-    return {
-      unbreakable: true,
-      stack: items,
-      margin: [0, 14, 0, 22]
-    };
-  }
-
-  /**
-   * Build manager/leadership section
-   * @param {Object} manager - Manager data
-   * @param {boolean} addPageBreak - Whether to add page break before section
-   */
-  buildManagerSection(manager, addPageBreak = false) {
-    const content = [];
-    const labels = this.getLabels();
-
-    content.push(...this.buildSectionHeader(labels.manager, addPageBreak));
-
-    const lang = this.currentLang;
-
-    // ── PM Capabilities ────────────────────────────────────
-    // Each capability is a richer card: title + description +
-    // bullet highlights + optional metrics chip line + tag chips.
-    if (manager.pmCapabilities && manager.pmCapabilities.length > 0) {
-      content.push(...this.buildSubsectionHeader(labels.pmCapabilities, false));
-
-      manager.pmCapabilities.forEach((cap, idx) => {
-        const items = [];
-
-        items.push({
-          text: [
-            { text: '◆ ', color: this.getColor('accent'), fontSize: 12, bold: true },
-            { text: this.getText(cap.title), color: this.getColor('primary'), bold: true, fontSize: 12 }
-          ],
-          margin: [0, idx === 0 ? 0 : 10, 0, 4]
-        });
-
-        if (cap.description) {
-          items.push({
-            text: this.getText(cap.description),
-            color: this.getColor('text.secondary'),
-            italics: true,
-            fontSize: 10.5,
-            lineHeight: 1.5,
-            margin: [16, 0, 0, 6]
-          });
-        }
-
-        const highlights = this.getArray(cap.highlights);
-        if (highlights.length > 0) {
-          items.push(this.buildBulletList(
-            highlights.map(h => this.stripHtml(this.getText(h))),
-            { markerColor: this.getColor('accent'), bottomMargin: 6 }
-          ));
-        }
-
-        const m = cap.metrics || {};
-        const chips = [];
-        if (Array.isArray(m.teamSizes) && m.teamSizes.length > 0) {
-          const min = Math.min(...m.teamSizes), max = Math.max(...m.teamSizes);
-          chips.push(`${lang === 'ko' ? '팀 규모' : 'Team Size'} ${min}–${max}`);
-        }
-        if (m.yearsLeading) chips.push(`${lang === 'ko' ? '리딩 연차' : 'Leading'} ${m.yearsLeading}+ ${lang === 'ko' ? '년' : 'yrs'}`);
-        if (m.projectsLed) chips.push(`${lang === 'ko' ? '리딩 프로젝트' : 'Projects Led'} ${m.projectsLed}+`);
-        if (m.onTimeDelivery) chips.push(`${lang === 'ko' ? '정시 납품' : 'On-Time'} ${m.onTimeDelivery}`);
-        if (m.certificationSuccess) chips.push(`${lang === 'ko' ? '인증 성공률' : 'Cert Success'} ${m.certificationSuccess}`);
-        if (m.majorProjects) chips.push(`${lang === 'ko' ? '주요 프로젝트' : 'Major Projects'} ${m.majorProjects}+`);
-
-        if (chips.length > 0) {
-          items.push({
-            text: chips.join('   ·   '),
-            color: this.getColor('accent'),
-            bold: true,
-            fontSize: 9,
-            margin: [16, 4, 0, 0]
-          });
-        }
-
-        const tags = this.getArray(cap.stakeholderTypes).concat(cap.frameworks || []);
-        if (tags.length > 0) {
-          items.push({
-            text: tags.map(t => this.getText(t)).join(' · '),
-            color: this.getColor('text.muted'),
-            fontSize: 9,
-            margin: [16, 4, 0, 0]
-          });
-        }
-
-        content.push({ unbreakable: true, stack: items, margin: [0, 0, 0, 4] });
-      });
-
-      content.push({ text: '', margin: [0, 0, 0, 10] });
-    }
-
-    // ── Leadership Style ───────────────────────────────────
-    if (manager.leadershipStyle) {
-      const principles = this.getArray(manager.leadershipStyle.principles);
-      if (principles.length > 0) {
-        content.push(...this.buildSubsectionHeader(labels.leadershipStyle, false));
-        content.push(this.buildBulletList(
-          principles.map(p => this.stripHtml(this.getText(p))),
-          { markerColor: this.getColor('accent') }
-        ));
-      }
-    }
-
-    // ── Business Impact ────────────────────────────────────
-    // keyNumbers intentionally omitted — already shown in cover-page stat
-    // infographic. Highlights remain as the qualitative narrative.
-    if (manager.businessImpact) {
-      const highlights = this.getArray(manager.businessImpact.highlights);
-      if (highlights.length > 0) {
-        content.push(...this.buildSubsectionHeader(labels.businessImpact, false));
-        content.push(this.buildBulletList(
-          highlights.map(h => this.stripHtml(this.getText(h))),
-          { markerColor: this.getColor('success') }
-        ));
-      }
-    }
-
-    // ── Soft Skills — 2-column descriptive grid ────────────
-    if (manager.softSkills && manager.softSkills.length > 0) {
-      content.push(...this.buildSubsectionHeader(labels.softSkills, false));
-
-      const buildSkillCell = (skill) => ({
-        stack: [
-          {
-            text: [
-              { text: '◆  ', color: this.getColor('accent'), fontSize: 11, bold: true },
-              { text: this.getText(skill.title), color: this.getColor('primary'), bold: true, fontSize: 11.5 }
-            ],
-            margin: [0, 0, 0, 5]
-          },
-          ...(skill.description ? [{
-            text: this.getText(skill.description),
-            color: this.getColor('text.secondary'),
-            fontSize: 9.5,
-            lineHeight: 1.55,
-            margin: [16, 0, 0, 0]
-          }] : [])
-        ]
-      });
-
-      const cells = manager.softSkills.map(buildSkillCell);
-      while (cells.length % 2 !== 0) cells.push({ text: '' });
-      const rows = [];
-      for (let i = 0; i < cells.length; i += 2) rows.push(cells.slice(i, i + 2));
-
-      content.push({
-        table: { widths: ['*', '*'], body: rows },
-        layout: {
-          hLineWidth: () => 0,
-          vLineWidth: () => 0,
-          paddingLeft: () => 10,
-          paddingRight: () => 10,
-          paddingTop: () => 10,
-          paddingBottom: () => 12
-        },
-        margin: [0, 0, 0, 6]
-      });
-    }
-
-    return content;
-  }
-
-  /**
-   * Format category name for display
-   */
-  formatCategoryName(category) {
-    const labels = this.getLabels();
-    const names = {
-      medicalImaging: labels.medicalImaging,
-      orthodontic: labels.orthodontic,
-      equipmentControl: labels.equipmentControl,
-      enterprise: labels.enterprise,
-      openSource: labels.openSource
-    };
-    return names[category] || category;
   }
 
   /**

--- a/portfolio/admin/utils/preview-renderer.js
+++ b/portfolio/admin/utils/preview-renderer.js
@@ -22,83 +22,78 @@ class DocumentPreviewRenderer {
   }
 
   /**
-   * Get current language
+   * Get current language.
+   * Prefers the export modal's language select (the value the exporters
+   * receive), falling back to the site language.
    * @returns {string} Current language code ('ko' or 'en')
    */
   getLang() {
+    const select = document.getElementById('export-language');
+    if (select && (select.value === 'ko' || select.value === 'en')) {
+      return select.value;
+    }
     return window.currentLanguage || window.getLanguage?.() || 'ko';
   }
 
   /**
-   * Get text from multilingual object { ko: "...", en: "..." }
+   * Get text from multilingual object { ko: "...", en: "..." }.
+   * Delegates to the shared ExportContent helper so the preview resolves
+   * text exactly like the exporters.
    * @param {*} obj - Multilingual object or string
    * @returns {string} Text in current language
    */
   getText(obj) {
+    if (window.ExportContent) {
+      return window.ExportContent.getTextIn(obj, this.currentLang);
+    }
     if (!obj) return '';
     if (typeof obj === 'string') return obj;
-    const lang = this.currentLang;
-    return obj[lang] || obj.ko || obj.en || '';
+    return obj[this.currentLang] || obj.ko || obj.en || '';
   }
 
   /**
-   * Get array from multilingual object { ko: [...], en: [...] }
+   * Get array from multilingual object { ko: [...], en: [...] }.
+   * Delegates to the shared ExportContent helper.
    * @param {*} obj - Multilingual array object or array
    * @returns {Array} Array in current language
    */
   getArray(obj) {
+    if (window.ExportContent) {
+      return window.ExportContent.getArrayIn(obj, this.currentLang);
+    }
     if (!obj) return [];
     if (Array.isArray(obj)) return obj;
-    const lang = this.currentLang;
-    return obj[lang] || obj.ko || obj.en || [];
+    return obj[this.currentLang] || obj.ko || obj.en || [];
   }
 
   /**
-   * Calculate duration from period string
+   * Get the localized export label dictionary shared with the exporters.
+   * @returns {Object} Label dictionary (empty object when unavailable)
+   */
+  getExportLabels() {
+    return window.ExportContent ? window.ExportContent.getLabels(this.currentLang) : {};
+  }
+
+  /**
+   * Strip HTML tags from a text value (same as the exporters' stripHtml).
+   * @param {string} text - Text possibly containing HTML tags
+   * @returns {string} Plain text
+   */
+  stripHtml(text) {
+    if (!text) return '';
+    return String(text).replace(/<[^>]*>/g, '');
+  }
+
+  /**
+   * Calculate duration from period string.
+   * Delegates to the shared ExportContent implementation (same rules as
+   * both exporters).
    * @param {string|Object} period - Period string or multilingual object
    * @returns {string|null} Formatted duration string
    */
   calculateDuration(period) {
-    const periodStr = this.getText(period);
-    if (!periodStr) return null;
-
-    const parts = periodStr.split(' - ');
-    if (parts.length !== 2) return null;
-
-    const parseDate = (str) => {
-      str = str.trim();
-      str = str.replace(/\s*\([^)]*\)\s*$/, '');
-      if (str.toLowerCase() === 'present' || str === '현재') {
-        return new Date();
-      }
-      const [year, month] = str.split('.');
-      return new Date(parseInt(year), month ? parseInt(month) - 1 : 0);
-    };
-
-    try {
-      const startDate = parseDate(parts[0]);
-      const endDate = parseDate(parts[1]);
-
-      const months = (endDate.getFullYear() - startDate.getFullYear()) * 12
-                   + (endDate.getMonth() - startDate.getMonth()) + 1;
-
-      if (months <= 0) return null;
-
-      const lang = this.currentLang;
-      if (months >= 12) {
-        const years = Math.floor(months / 12);
-        const remainingMonths = months % 12;
-        if (remainingMonths === 0) {
-          return lang === 'ko' ? `${years}년` : `${years} yr${years > 1 ? 's' : ''}`;
-        }
-        return lang === 'ko'
-          ? `${years}년 ${remainingMonths}개월`
-          : `${years} yr${years > 1 ? 's' : ''} ${remainingMonths} mo`;
-      }
-      return lang === 'ko' ? `${months}개월` : `${months} mo`;
-    } catch (e) {
-      return null;
-    }
+    if (!window.ExportContent) return null;
+    return window.ExportContent.calculateDuration(period, this.currentLang);
   }
 
   /**
@@ -179,6 +174,10 @@ class DocumentPreviewRenderer {
    * @param {Array} sections - Selected sections to include
    * @param {Object} options - Additional options
    * @param {boolean} options.pageBreakBetweenSections - Whether to insert page breaks between sections
+   * @param {boolean} [options.includeCoverPage] - Show the cover page (defaults to true, like the exporters)
+   * @param {boolean} [options.includeCoverLetter] - Show the cover letter (defaults to the export-modal checkbox)
+   * @param {string[]} [options.personalInfoFields] - Personal-info field IDs (defaults to the export-modal checkboxes)
+   * @param {string} [options.language] - Language code (defaults to the export-modal language select)
    */
   update(data, theme, sections, options = {}) {
     clearTimeout(this.debounceTimer);
@@ -210,66 +209,323 @@ class DocumentPreviewRenderer {
       return [{ elements: [{ type: 'empty', text: 'No content available', y: 100 }] }];
     }
 
-    const { pageBreakBetweenSections = false } = options;
-    const pages = [];
+    const resolved = this.resolveExportOptions(options);
     const pageHeight = 842;
     const contentHeight = pageHeight - this.theme.spacing.page.marginTop - this.theme.spacing.page.marginBottom;
 
-    let currentPage = { elements: [], currentY: 0 };
+    const state = { pages: [], page: { elements: [], currentY: 0 } };
 
-    // Add header
-    currentPage.elements.push({
-      type: 'header',
-      text: 'Portfolio',
-      y: 0
-    });
-    currentPage.currentY += 60;
+    // Cover page — both exporters include it by default (admin.js never
+    // disables it), so the preview shows it as page 1.
+    if (resolved.includeCoverPage) {
+      this.flowElements(this.buildCoverPageElements(data, resolved.personalInfoFields), state, contentHeight);
+    }
 
-    // Process each section
+    // Cover letter — occupies its own page right after the cover, matching
+    // both exporters (pageBreakBefore on the letter).
+    let letterPlaced = false;
+    if (resolved.includeCoverLetter) {
+      const template = this.loadCoverLetterTemplate();
+      if (template) {
+        this.breakPage(state);
+        this.flowElements(this.buildCoverLetterElements(template), state, contentHeight);
+        letterPlaced = true;
+      }
+    }
+
+    // Inline header replaces the cover page when the cover is disabled
+    // (exporters render buildHeader only when includeCoverPage is false).
+    if (!resolved.includeCoverPage) {
+      if (letterPlaced) this.breakPage(state);
+      const author = this.currentLang === 'ko' ? '신동철' : 'Dongcheol Shin';
+      state.page.elements.push({ type: 'header', text: author, y: state.page.currentY, height: 60 });
+      state.page.currentY += 60;
+    }
+
+    // Sections. Exporter rule: once a cover page or cover letter is placed,
+    // every section starts on a new page; otherwise page breaks follow the
+    // "page break between sections" option (skipping the first section).
+    const headPlaced = resolved.includeCoverPage || letterPlaced;
     sections.forEach((sectionId, sectionIndex) => {
       const sectionData = data[sectionId];
       if (!sectionData) return;
 
-      // Insert page break before section (except the first)
-      if (pageBreakBetweenSections && sectionIndex > 0) {
-        // Push current page and start a new one
-        if (currentPage.elements.length > 0) {
-          pages.push(currentPage);
-        }
-        currentPage = { elements: [], currentY: 0 };
+      const breakBefore = headPlaced
+        ? true
+        : (resolved.pageBreakBetweenSections && sectionIndex > 0);
+      if (breakBefore) this.breakPage(state);
+
+      this.flowElements(this.buildSectionElements(sectionId, sectionData), state, contentHeight);
+    });
+
+    if (state.page.elements.length > 0) {
+      state.pages.push(state.page);
+    }
+
+    return state.pages.length > 0 ? state.pages : [{ elements: [{ type: 'empty', text: 'No content selected', y: 100 }] }];
+  }
+
+  /**
+   * Resolve export options the same way the exporters receive them.
+   * admin.js only passes pageBreakBetweenSections to the preview, so the
+   * remaining values are read from the live export-modal controls, falling
+   * back to the same localStorage keys admin.js persists for the exporters.
+   * @param {Object} options - Options passed to update()
+   * @returns {Object} Resolved options
+   */
+  resolveExportOptions(options = {}) {
+    const letterCheckbox = document.getElementById('include-cover-letter');
+    const includeCoverLetter = options.includeCoverLetter !== undefined
+      ? !!options.includeCoverLetter
+      : (letterCheckbox
+        ? letterCheckbox.checked
+        : localStorage.getItem('export-include-cover-letter') === 'true');
+
+    // Both exporters default includeCoverPage to true and admin.js never
+    // overrides it, so the preview defaults to true as well.
+    const includeCoverPage = options.includeCoverPage !== undefined
+      ? !!options.includeCoverPage
+      : true;
+
+    const pageBreakBetweenSections = options.pageBreakBetweenSections !== undefined
+      ? !!options.pageBreakBetweenSections
+      : localStorage.getItem('export-page-break-sections') === 'true';
+
+    let personalInfoFields = Array.isArray(options.personalInfoFields)
+      ? options.personalInfoFields
+      : null;
+    if (!personalInfoFields) {
+      personalInfoFields = Array.from(
+        document.querySelectorAll('.personal-info-field-input:checked')
+      ).map(el => el.dataset.fieldId);
+    }
+
+    return { includeCoverLetter, includeCoverPage, pageBreakBetweenSections, personalInfoFields };
+  }
+
+  /**
+   * Push the current page (when non-empty) and start a new one.
+   * @param {Object} state - Pagination state ({ pages, page })
+   */
+  breakPage(state) {
+    if (state.page.elements.length > 0) {
+      state.pages.push(state.page);
+      state.page = { elements: [], currentY: 0 };
+    }
+  }
+
+  /**
+   * Flow elements onto pages, breaking when an element does not fit.
+   * @param {Array} elements - Elements to place
+   * @param {Object} state - Pagination state ({ pages, page })
+   * @param {number} contentHeight - Usable page height
+   */
+  flowElements(elements, state, contentHeight) {
+    elements.forEach(element => {
+      // Check if element fits on current page (groups use total group height)
+      if (state.page.currentY + element.height > contentHeight && state.page.elements.length > 0) {
+        state.pages.push(state.page);
+        state.page = { elements: [], currentY: 0 };
       }
 
-      const sectionElements = this.buildSectionElements(sectionId, sectionData);
+      // Handle group elements - set relative y positions for items
+      if (element.type === 'group' && element.items) {
+        element.y = state.page.currentY;
+        let itemY = 0;
+        element.items.forEach(item => {
+          item.relativeY = itemY;
+          itemY += item.height + 3;
+        });
+      } else {
+        element.y = state.page.currentY;
+      }
 
-      sectionElements.forEach(element => {
-        // Check if element fits on current page (groups use total group height)
-        if (currentPage.currentY + element.height > contentHeight) {
-          pages.push(currentPage);
-          currentPage = { elements: [], currentY: 0 };
+      state.page.elements.push(element);
+      state.page.currentY += element.height + 5;
+    });
+  }
+
+  /**
+   * Load the cover letter template with the same resolution order as the
+   * exporters: optional getter functions first, then the template selected
+   * in localStorage, then the first available template.
+   * @returns {Object|null} Cover letter template or null
+   */
+  loadCoverLetterTemplate() {
+    try {
+      if (window.parent && typeof window.parent.getCoverLetterTemplate === 'function') {
+        const t = window.parent.getCoverLetterTemplate();
+        if (t) return t;
+      }
+      if (typeof window.getCoverLetterTemplate === 'function') {
+        const t = window.getCoverLetterTemplate();
+        if (t) return t;
+      }
+
+      if (window.PortfolioData && window.PortfolioData.coverLetter) {
+        const templates = window.PortfolioData.coverLetter.templates || [];
+        if (templates.length === 0) return null;
+        const selectedId = (typeof localStorage !== 'undefined')
+          ? localStorage.getItem('cover-letter-template-id')
+          : null;
+        if (selectedId) {
+          const found = templates.find(t => t.id === selectedId);
+          if (found) return found;
         }
+        return templates[0];
+      }
 
-        // Handle group elements - set relative y positions for items
-        if (element.type === 'group' && element.items) {
-          element.y = currentPage.currentY;
-          let itemY = 0;
-          element.items.forEach(item => {
-            item.relativeY = itemY;
-            itemY += item.height + 3;
-          });
-        } else {
-          element.y = currentPage.currentY;
-        }
+      return null;
+    } catch (e) {
+      return null;
+    }
+  }
 
-        currentPage.elements.push(element);
-        currentPage.currentY += element.height + 5;
+  /**
+   * Estimate the rendered height of wrapped paragraph text.
+   * CJK glyphs count as full-width, Latin glyphs as ~0.55em; line height
+   * matches the factor used by wrapText (fontSize * 1.4).
+   * @param {string} text - Text to measure
+   * @param {number} fontSize - Font size in px
+   * @returns {number} Estimated height in px
+   */
+  estimateWrappedHeight(text, fontSize) {
+    const str = String(text || '');
+    const contentWidth = 595 - this.theme.spacing.page.marginLeft - this.theme.spacing.page.marginRight;
+    let width = 0;
+    const cjkPattern = /[ᄀ-ᇿ　-鿿가-힣]/;
+    for (const ch of str) {
+      width += cjkPattern.test(ch) ? fontSize : fontSize * 0.55;
+    }
+    const lines = Math.max(1, Math.ceil(width / Math.max(contentWidth, 1)));
+    return Math.round(lines * fontSize * 1.4) + 6;
+  }
+
+  /**
+   * Build cover page elements (name, role line, optional personal info,
+   * executive summary, stats infographic, certifications) mirroring the
+   * exporters' buildCoverPage.
+   * @param {Object} data - Portfolio data
+   * @param {string[]} personalInfoFields - Selected personal-info field IDs
+   * @returns {Array} Element list
+   */
+  buildCoverPageElements(data, personalInfoFields) {
+    const { typography } = this.theme;
+    const lang = this.currentLang;
+    const ec = window.ExportContent;
+    const elements = [];
+
+    // Same author resolution as the exporters / admin.js
+    const author = lang === 'ko' ? '신동철' : 'Dongcheol Shin';
+    elements.push({ type: 'coverName', text: author, height: 48 });
+
+    const subtitle = ec ? ec.getCoverSubtitle(lang, data.profile) : '';
+    if (subtitle) {
+      elements.push({ type: 'coverSubtitle', text: subtitle, height: typography.fontSize.h3 + 14 });
+    }
+
+    // Personal info row — only the fields selected in the export modal
+    if (personalInfoFields.length > 0 && data.profile && Array.isArray(data.profile.fields)) {
+      const byId = new Map(data.profile.fields.map(f => [f.id, f]));
+      const parts = personalInfoFields
+        .map(id => byId.get(id))
+        .filter(Boolean)
+        .map(f => this.getText(f.value))
+        .filter(v => v && v.length > 0);
+      if (parts.length > 0) {
+        elements.push({ type: 'date', text: parts.join('   ·   '), height: typography.fontSize.small + 8 });
+      }
+    }
+
+    const summaryLines = ec ? ec.getCoverSummaryLines(lang, data.profile) : [];
+    summaryLines.forEach(line => {
+      elements.push({
+        type: 'paragraph',
+        text: line,
+        height: this.estimateWrappedHeight(line, typography.fontSize.body)
       });
     });
 
-    if (currentPage.elements.length > 0) {
-      pages.push(currentPage);
+    elements.push({ type: 'divider', height: 14 });
+
+    const stats = this.buildCoverStats(data);
+    if (stats.length > 0) {
+      elements.push({ type: 'statsRow', stats, height: 64 });
     }
 
-    return pages.length > 0 ? pages : [{ elements: [{ type: 'empty', text: 'No content selected', y: 100 }] }];
+    if (data?.expertise?.certifications?.length > 0) {
+      const certText = data.expertise.certifications
+        .map(c => this.getText(c.name)).join('  ·  ');
+      elements.push({
+        type: 'date',
+        text: lang === 'ko' ? '인증 / Certifications' : 'Certifications',
+        height: typography.fontSize.small + 8
+      });
+      elements.push({ type: 'subheading', text: certText, height: typography.fontSize.h3 + 10 });
+    }
+
+    return elements;
+  }
+
+  /**
+   * Build cover-page stats with the same selection rule as the exporters'
+   * buildStatsTable (max 4 entries).
+   * @param {Object} data - Portfolio data
+   * @returns {Array<{value: string, label: string}>} Stats entries
+   */
+  buildCoverStats(data) {
+    const lang = this.currentLang;
+    const kn = data?.manager?.businessImpact?.keyNumbers || {};
+    const certCount = data?.expertise?.certifications?.length || kn.certifications;
+    const stats = [];
+
+    stats.push({ value: '20+', label: lang === 'ko' ? '경력 (년)' : 'Years' });
+    if (certCount) stats.push({ value: String(certCount), label: lang === 'ko' ? '글로벌 인증' : 'Certifications' });
+    if (kn.ipos) stats.push({ value: String(kn.ipos), label: 'IPO' });
+    if (kn.performanceImprovement) stats.push({ value: String(kn.performanceImprovement), label: lang === 'ko' ? '성능 향상' : 'Performance' });
+    if (kn.projectsDelivered && stats.length < 4) {
+      stats.push({ value: String(kn.projectsDelivered), label: lang === 'ko' ? '프로젝트' : 'Projects' });
+    }
+
+    return stats.slice(0, 4);
+  }
+
+  /**
+   * Build cover letter elements (greeting, opening, key points, closing,
+   * signature) as text blocks. Bold markers (**) are stripped since the
+   * canvas preview renders single-style text.
+   * @param {Object} template - Cover letter template
+   * @returns {Array} Element list
+   */
+  buildCoverLetterElements(template) {
+    const { typography } = this.theme;
+    const body = typography.fontSize.body;
+    const elements = [];
+
+    const pushParagraph = (text, extra = 0) => {
+      if (!text) return;
+      elements.push({
+        type: 'paragraph',
+        text,
+        height: this.estimateWrappedHeight(text, body) + extra
+      });
+    };
+
+    pushParagraph(this.getText(template.greeting), 6);
+
+    const position = this.getText(template.targetRole);
+    const opening = this.getText(template.opening).replace('{position}', position);
+    pushParagraph(this.stripHtml(opening).replace(/\*\*/g, ''), 6);
+
+    this.getArray(template.keyPoints).forEach(point => {
+      const text = this.stripHtml(this.getText(point)).replace(/\*\*/g, '');
+      if (text) pushParagraph(`•  ${text}`);
+    });
+
+    pushParagraph(this.stripHtml(this.getText(template.closing)).replace(/\*\*/g, ''), 6);
+    pushParagraph(this.getText(template.signature), 10);
+
+    return elements;
   }
 
   /**
@@ -303,6 +559,10 @@ class DocumentPreviewRenderer {
         this.buildCareerElements(elements, data, typography);
         break;
 
+      case 'manager':
+        this.buildManagerElements(elements, data, typography);
+        break;
+
       case 'testimonials':
         this.buildTestimonialsElements(elements, data, typography);
         break;
@@ -317,6 +577,149 @@ class DocumentPreviewRenderer {
     }
 
     return elements;
+  }
+
+  /**
+   * Build manager (Leadership & Management) section elements.
+   * Mirrors the exporters' buildManagerSection: PM capabilities (title,
+   * description, highlights, metric chips, tags), leadership principles,
+   * business impact highlights, and soft skills. keyNumbers are omitted
+   * here as well — they appear on the cover-page stats infographic.
+   */
+  buildManagerElements(elements, data, typography) {
+    const labels = this.getExportLabels();
+    const lang = this.currentLang;
+
+    // PM Capabilities
+    if (Array.isArray(data.pmCapabilities) && data.pmCapabilities.length > 0) {
+      elements.push({
+        type: 'subheading',
+        text: labels.pmCapabilities || 'PM Capabilities',
+        height: typography.fontSize.h3 + 10
+      });
+
+      data.pmCapabilities.forEach(cap => {
+        const groupItems = [];
+        groupItems.push({
+          type: 'projectTitle',
+          text: this.getText(cap.title),
+          height: typography.fontSize.h3 + 8
+        });
+        if (cap.description) {
+          const desc = this.getText(cap.description);
+          groupItems.push({
+            type: 'paragraph',
+            text: desc,
+            height: this.estimateWrappedHeight(desc, typography.fontSize.body)
+          });
+        }
+        this.getArray(cap.highlights).forEach(h => {
+          groupItems.push({
+            type: 'bullet',
+            text: this.stripHtml(this.getText(h)),
+            height: typography.fontSize.body + 8
+          });
+        });
+        const chips = this.buildManagerMetricChips(cap.metrics, lang);
+        if (chips.length > 0) {
+          groupItems.push({
+            type: 'date',
+            text: chips.join('   ·   '),
+            height: typography.fontSize.small + 6
+          });
+        }
+        const tags = this.getArray(cap.stakeholderTypes).concat(cap.frameworks || []);
+        if (tags.length > 0) {
+          groupItems.push({
+            type: 'date',
+            text: tags.map(t => this.getText(t)).join(' · '),
+            height: typography.fontSize.small + 6
+          });
+        }
+        elements.push({
+          type: 'group',
+          items: groupItems,
+          height: groupItems.reduce((sum, item) => sum + item.height, 0) + 5
+        });
+      });
+    }
+
+    // Leadership Style principles
+    const principles = data.leadershipStyle ? this.getArray(data.leadershipStyle.principles) : [];
+    if (principles.length > 0) {
+      elements.push({
+        type: 'subheading',
+        text: labels.leadershipStyle || 'Leadership Style',
+        height: typography.fontSize.h3 + 10
+      });
+      principles.forEach(p => {
+        elements.push({
+          type: 'bullet',
+          text: this.stripHtml(this.getText(p)),
+          height: typography.fontSize.body + 8
+        });
+      });
+    }
+
+    // Business Impact highlights (keyNumbers intentionally omitted)
+    const impactHighlights = data.businessImpact ? this.getArray(data.businessImpact.highlights) : [];
+    if (impactHighlights.length > 0) {
+      elements.push({
+        type: 'subheading',
+        text: labels.businessImpact || 'Business Impact',
+        height: typography.fontSize.h3 + 10
+      });
+      impactHighlights.forEach(h => {
+        elements.push({
+          type: 'bullet',
+          text: this.stripHtml(this.getText(h)),
+          height: typography.fontSize.body + 8
+        });
+      });
+    }
+
+    // Soft Skills — exporters use a 2-column grid; the preview approximates
+    // it as a flat "title — description" list.
+    if (Array.isArray(data.softSkills) && data.softSkills.length > 0) {
+      elements.push({
+        type: 'subheading',
+        text: labels.softSkills || 'Soft Skills',
+        height: typography.fontSize.h3 + 10
+      });
+      data.softSkills.forEach(skill => {
+        const title = this.getText(skill.title);
+        const desc = this.getText(skill.description);
+        const text = desc ? `${title} — ${desc}` : title;
+        elements.push({
+          type: 'paragraph',
+          text: `•  ${text}`,
+          height: this.estimateWrappedHeight(text, typography.fontSize.body)
+        });
+      });
+    }
+  }
+
+  /**
+   * Build metric chip strings for a PM capability, matching the exporters'
+   * chip labels and order.
+   * @param {Object} metrics - Capability metrics object
+   * @param {string} lang - Language code ('ko' or 'en')
+   * @returns {string[]} Chip strings
+   */
+  buildManagerMetricChips(metrics, lang) {
+    const m = metrics || {};
+    const chips = [];
+    if (Array.isArray(m.teamSizes) && m.teamSizes.length > 0) {
+      const min = Math.min(...m.teamSizes);
+      const max = Math.max(...m.teamSizes);
+      chips.push(`${lang === 'ko' ? '팀 규모' : 'Team Size'} ${min}–${max}`);
+    }
+    if (m.yearsLeading) chips.push(`${lang === 'ko' ? '리딩 연차' : 'Leading'} ${m.yearsLeading}+ ${lang === 'ko' ? '년' : 'yrs'}`);
+    if (m.projectsLed) chips.push(`${lang === 'ko' ? '리딩 프로젝트' : 'Projects Led'} ${m.projectsLed}+`);
+    if (m.onTimeDelivery) chips.push(`${lang === 'ko' ? '정시 납품' : 'On-Time'} ${m.onTimeDelivery}`);
+    if (m.certificationSuccess) chips.push(`${lang === 'ko' ? '인증 성공률' : 'Cert Success'} ${m.certificationSuccess}`);
+    if (m.majorProjects) chips.push(`${lang === 'ko' ? '주요 프로젝트' : 'Major Projects'} ${m.majorProjects}+`);
+    return chips;
   }
 
   /**
@@ -516,15 +919,11 @@ class DocumentPreviewRenderer {
    * @returns {string} Formatted title
    */
   formatSectionTitle(sectionId) {
-    const titles = {
-      expertise: 'Expertise',
-      projects: 'Projects',
-      career: 'Career',
-      education: 'Education',
-      testimonials: 'Testimonials',
-      compensation: 'Compensation (private)'
-    };
-    return titles[sectionId] || sectionId.charAt(0).toUpperCase() + sectionId.slice(1);
+    // Section titles come from the shared exporter label source so the
+    // preview matches the exported document in both languages.
+    const labels = this.getExportLabels();
+    if (labels[sectionId]) return labels[sectionId];
+    return sectionId.charAt(0).toUpperCase() + sectionId.slice(1);
   }
 
   /**
@@ -651,6 +1050,49 @@ class DocumentPreviewRenderer {
         this.ctx.fillStyle = colors.text.muted;
         this.ctx.fillText(element.text, x + 20, y + typography.fontSize.small);
         break;
+
+      case 'coverName':
+        this.ctx.font = `bold 32px ${fontFamily}`;
+        this.ctx.fillStyle = colors.text.primary;
+        this.ctx.fillText(element.text, x, y + 32);
+        break;
+
+      case 'coverSubtitle':
+        this.ctx.font = `bold ${typography.fontSize.h3}px ${fontFamily}`;
+        this.ctx.fillStyle = colors.primary;
+        this.ctx.fillText(element.text, x, y + typography.fontSize.h3);
+        break;
+
+      case 'divider':
+        this.ctx.strokeStyle = colors.border || '#ddd';
+        this.ctx.lineWidth = 1;
+        this.ctx.beginPath();
+        this.ctx.moveTo(x, y + 6);
+        this.ctx.lineTo(x + contentWidth, y + 6);
+        this.ctx.stroke();
+        break;
+
+      case 'statsRow': {
+        const stats = element.stats || [];
+        if (stats.length === 0) break;
+        const gap = 6;
+        const cellW = (contentWidth - gap * (stats.length - 1)) / stats.length;
+        const valueH = 34;
+        stats.forEach((s, i) => {
+          const cellX = x + i * (cellW + gap);
+          this.ctx.fillStyle = colors.primary;
+          this.ctx.fillRect(cellX, y, cellW, valueH);
+          this.ctx.fillStyle = '#FFFFFF';
+          this.ctx.font = `bold 16px ${fontFamily}`;
+          this.ctx.textAlign = 'center';
+          this.ctx.fillText(s.value, cellX + cellW / 2, y + 23);
+          this.ctx.fillStyle = colors.text.secondary;
+          this.ctx.font = `${typography.fontSize.small}px ${fontFamily}`;
+          this.ctx.fillText(s.label, cellX + cellW / 2, y + valueH + typography.fontSize.small + 4);
+        });
+        this.ctx.textAlign = 'left';
+        break;
+      }
 
       case 'empty':
         this.ctx.font = `italic ${typography.fontSize.body}px ${fontFamily}`;

--- a/portfolio/components/components.js
+++ b/portfolio/components/components.js
@@ -10,6 +10,17 @@ const _getLang = () => window.getLang?.() || window.i18nUtils?.getLang?.() || 'k
 const _getText = (obj) => window.getText?.(obj) ?? window.i18nUtils?.getText?.(obj) ?? (typeof obj === 'string' ? obj : obj?.ko || obj?.en || '');
 const _getArray = (obj) => window.getArray?.(obj) ?? window.i18nUtils?.getArray?.(obj) ?? (Array.isArray(obj) ? obj : obj?.ko || obj?.en || []);
 const _t = (key) => window.i18nUtils?.t?.(key) ?? window.translations?.[_getLang()]?.[key] ?? key;
+// HTML-escape data-derived values before template interpolation (shared impl in utils/i18n.js).
+// Intentional-markup exceptions rendered without _esc (fields authored with <strong> in JSON):
+// projects[].description, testimonials featured.quote / testimonials[].text,
+// career timeline[].note, expertise categories[].items.
+const _esc = (v) => (window.escapeHtml ?? window.i18nUtils?.escapeHtml)?.(v)
+    ?? String(v ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;');
+// Guard for URLs interpolated into href/src: allow only http(s), neutralize anything else.
+const _safeUrl = (url) => {
+    const s = String(url ?? '').trim();
+    return /^https?:\/\//i.test(s) ? _esc(s) : '#';
+};
 
 // Icon SVG definitions - Consolidated for all sections
 const Icons = {
@@ -66,8 +77,9 @@ const ProjectIconMap = {
 const _calculateDuration = (period) => window.calculateDuration?.(period) ?? window.i18nUtils?.calculateDuration?.(period) ?? null;
 
 // Render period with duration
+// periodStr is data-derived (escaped); duration is built internally from parsed numbers (safe)
 function renderPeriodWithDuration(period) {
-    const periodStr = _getText(period);
+    const periodStr = _esc(_getText(period));
     const duration = _calculateDuration(period);
     if (duration) {
         return `<span class="project-period">${periodStr} <span class="project-duration">(${duration})</span></span>`;
@@ -84,13 +96,13 @@ function renderRoleBadges(roles) {
         'qa-doc': 'QA Doc'
     };
     return roles.map(role =>
-        `<span class="role-badge ${role}">${roleLabels[role] || role}</span>`
+        `<span class="role-badge ${_esc(role)}">${_esc(roleLabels[role] || role)}</span>`
     ).join('');
 }
 
 // Render tags
 function renderTags(tags) {
-    return tags.map(tag => `<span class="tag">${tag}</span>`).join('');
+    return tags.map(tag => `<span class="tag">${_esc(tag)}</span>`).join('');
 }
 
 // Render metrics
@@ -100,9 +112,9 @@ function renderMetrics(metrics) {
         <div class="project-metrics">
             ${metrics.map(m => `
                 <div class="metric">
-                    <span class="metric-value">${_getText(m.value)}</span>
-                    <span class="metric-label">${_getText(m.label)}</span>
-                    ${m.change ? `<span class="metric-change ${m.positive ? 'positive' : ''}">${_getText(m.change)}</span>` : ''}
+                    <span class="metric-value">${_esc(_getText(m.value))}</span>
+                    <span class="metric-label">${_esc(_getText(m.label))}</span>
+                    ${m.change ? `<span class="metric-change ${m.positive ? 'positive' : ''}">${_esc(_getText(m.change))}</span>` : ''}
                 </div>
             `).join('')}
         </div>
@@ -118,20 +130,21 @@ function renderCertifications(certs) {
         <div class="expanded-section">
             <h4>${label}</h4>
             <div class="cert-badges">
-                ${certs.map(cert => `<span class="cert-badge">${cert}</span>`).join('')}
+                ${certs.map(cert => `<span class="cert-badge">${_esc(cert)}</span>`).join('')}
             </div>
         </div>
     `;
 }
 
 // Render expanded section list
+// title is an internal label constant (not escaped); items are data-derived (escaped)
 function renderExpandedList(title, items) {
     if (!items || items.length === 0) return '';
     return `
         <div class="expanded-section">
             <h4>${title}</h4>
             <ul>
-                ${items.map(item => `<li>${item}</li>`).join('')}
+                ${items.map(item => `<li>${_esc(item)}</li>`).join('')}
             </ul>
         </div>
     `;
@@ -146,15 +159,15 @@ function renderFeaturedProject(project) {
         : { roles: 'Roles', challenges: 'Challenges', solutions: 'Solutions', achievements: 'Achievements' };
 
     return `
-        <article class="project-card featured expandable" id="project-${project.id}">
+        <article class="project-card featured expandable" id="project-${_esc(project.id)}">
             <div class="project-header">
                 <div class="project-icon">${iconSvg}</div>
                 <div class="project-meta">
                     <span class="project-badge">Featured</span>
-                    <span class="project-company">${_getText(project.company)}</span>
+                    <span class="project-company">${_esc(_getText(project.company))}</span>
                 </div>
             </div>
-            <h3 class="project-title">${_getText(project.title)}</h3>
+            <h3 class="project-title">${_esc(_getText(project.title))}</h3>
             ${renderPeriodWithDuration(project.period)}
             <div class="role-badges">${renderRoleBadges(project.roles)}</div>
             <p class="project-description">${_getText(project.description)}</p>
@@ -183,11 +196,11 @@ function renderProjectCard(project) {
         : { roles: 'Roles', challenges: 'Challenges', solutions: 'Solutions' };
 
     return `
-        <article class="project-card expandable" id="project-${project.id}">
+        <article class="project-card expandable" id="project-${_esc(project.id)}">
             <div class="project-header">
-                <span class="project-company-small">${_getText(project.company)}</span>
+                <span class="project-company-small">${_esc(_getText(project.company))}</span>
             </div>
-            <h3 class="project-title">${_getText(project.title)}</h3>
+            <h3 class="project-title">${_esc(_getText(project.title))}</h3>
             ${renderPeriodWithDuration(project.period)}
             <div class="role-badges">${renderRoleBadges(project.roles)}</div>
             <p class="project-description">${_getText(project.description)}</p>
@@ -217,16 +230,16 @@ function renderOpenSourceCard(project) {
         : { features: 'Key Features', performance: 'Performance', viewOnGithub: 'View on GitHub' };
 
     return `
-        <article class="project-card opensource expandable" id="project-${project.id}">
+        <article class="project-card opensource expandable" id="project-${_esc(project.id)}">
             <div class="project-header">
                 <span class="project-company-small">Open Source</span>
-                <a href="${project.github}" target="_blank" rel="noopener noreferrer" class="github-link" title="${labels.viewOnGithub}">
+                <a href="${_safeUrl(project.github)}" target="_blank" rel="noopener noreferrer" class="github-link" title="${labels.viewOnGithub}">
                     ${Icons.github}
                 </a>
             </div>
-            <h3 class="project-title">${_getText(project.title)}</h3>
-            ${project.period ? `<span class="project-period">${_getText(project.period)}</span>` : ''}
-            ${project.stars ? `<div class="project-stats"><span class="star-count">${project.stars} stars</span></div>` : ''}
+            <h3 class="project-title">${_esc(_getText(project.title))}</h3>
+            ${project.period ? `<span class="project-period">${_esc(_getText(project.period))}</span>` : ''}
+            ${project.stars ? `<div class="project-stats"><span class="star-count">${_esc(project.stars)} stars</span></div>` : ''}
             <p class="project-description">${_getText(project.description)}</p>
             <div class="project-tags">${renderTags(project.tags)}</div>
             <button class="expand-btn" aria-expanded="false">
@@ -360,7 +373,7 @@ function renderTestimonials(data, container) {
         if (!labels) return '';
         const arr = _getArray(labels);
         return arr.map(l =>
-            `<span class="testimonial-label ${l.type}">${_getText(l.text)}</span>`
+            `<span class="testimonial-label ${_esc(l.type)}">${_esc(_getText(l.text))}</span>`
         ).join('');
     };
 
@@ -374,9 +387,9 @@ function renderTestimonials(data, container) {
                 <p class="testimonial-quote">"${_getText(data.featured.quote)}"</p>
                 <div class="testimonial-labels">${renderLabels(data.featured.labels)}</div>
                 <footer class="testimonial-author">
-                    <span class="author-name">${_getText(data.featured.author)}</span>
-                    <span class="author-role">${_getText(data.featured.role)}</span>
-                    <span class="author-relation">${_getText(data.featured.relation)}</span>
+                    <span class="author-name">${_esc(_getText(data.featured.author))}</span>
+                    <span class="author-role">${_esc(_getText(data.featured.role))}</span>
+                    <span class="author-relation">${_esc(_getText(data.featured.relation))}</span>
                 </footer>
             </blockquote>
         </div>
@@ -385,15 +398,15 @@ function renderTestimonials(data, container) {
             ${data.testimonials.map(item => `
                 <div class="testimonial-card">
                     <div class="testimonial-meta">
-                        <span class="testimonial-date">${item.date}</span>
-                        <span class="testimonial-context">${_getText(item.context)}</span>
+                        <span class="testimonial-date">${_esc(item.date)}</span>
+                        <span class="testimonial-context">${_esc(_getText(item.context))}</span>
                     </div>
                     <p class="testimonial-text">"${_getText(item.text)}"</p>
                     <div class="testimonial-labels">${renderLabels(item.labels)}</div>
                     <footer class="testimonial-author">
-                        <span class="author-name">${_getText(item.author)}</span>
-                        <span class="author-role">${_getText(item.role)}</span>
-                        <span class="author-relation">${_getText(item.relation)}</span>
+                        <span class="author-name">${_esc(_getText(item.author))}</span>
+                        <span class="author-role">${_esc(_getText(item.role))}</span>
+                        <span class="author-relation">${_esc(_getText(item.relation))}</span>
                     </footer>
                 </div>
             `).join('')}
@@ -439,7 +452,7 @@ function renderCareer(data, container) {
             <div class="timeline-related-projects">
                 <strong>${labels.relatedProjects}:</strong>
                 <div class="project-links">
-                    ${projectIds.map(id => `<a href="#project-${id}" class="project-link" data-project-id="${id}">${getProjectTitle(id)}</a>`).join('')}
+                    ${projectIds.map(id => `<a href="#project-${_esc(id)}" class="project-link" data-project-id="${_esc(id)}">${_esc(getProjectTitle(id))}</a>`).join('')}
                 </div>
             </div>
         `;
@@ -449,6 +462,8 @@ function renderCareer(data, container) {
         let periodStr = _getText(period);
         // Remove any existing duration from the period string
         periodStr = periodStr.replace(/\s*\([^)]*(?:개월|년|months?|yrs?|mo)[^)]*\)/gi, '').trim();
+        // periodStr is data-derived (escaped); duration is built internally from parsed numbers (safe)
+        periodStr = _esc(periodStr);
         const duration = _calculateDuration(period);
         if (duration) {
             return `${periodStr} <span class="timeline-duration">(${duration})</span>`;
@@ -462,7 +477,7 @@ function renderCareer(data, container) {
         if (arr.length === 0) return '';
         return `
             <ul class="timeline-achievements">
-                ${arr.map(a => `<li>${_getText(a)}</li>`).join('')}
+                ${arr.map(a => `<li>${_esc(_getText(a))}</li>`).join('')}
             </ul>
         `;
     };
@@ -471,8 +486,8 @@ function renderCareer(data, container) {
         if (!scale) return '';
         return `
             <div class="timeline-scale">
-                ${scale.company ? `<span class="scale-item"><strong>${labels.companyScale}:</strong> ${_getText(scale.company)}</span>` : ''}
-                ${scale.team ? `<span class="scale-item"><strong>${labels.teamScale}:</strong> ${_getText(scale.team)}</span>` : ''}
+                ${scale.company ? `<span class="scale-item"><strong>${labels.companyScale}:</strong> ${_esc(_getText(scale.company))}</span>` : ''}
+                ${scale.team ? `<span class="scale-item"><strong>${labels.teamScale}:</strong> ${_esc(_getText(scale.team))}</span>` : ''}
             </div>
         `;
     };
@@ -485,18 +500,18 @@ function renderCareer(data, container) {
                     <div class="timeline-marker"></div>
                     <div class="timeline-content">
                         <div class="timeline-header">
-                            <h3 class="timeline-title">${_getText(item.company)}</h3>
+                            <h3 class="timeline-title">${_esc(_getText(item.company))}</h3>
                             <span class="timeline-period">${renderTimelinePeriod(item.period)}</span>
-                            ${item.badge ? `<span class="timeline-badge">${_getText(item.badge)}</span>` : ''}
+                            ${item.badge ? `<span class="timeline-badge">${_esc(_getText(item.badge))}</span>` : ''}
                         </div>
-                        <p class="timeline-role">${_getText(item.role)}</p>
-                        ${item.companyDescription ? `<p class="timeline-company-desc">${_getText(item.companyDescription)}</p>` : ''}
-                        ${item.description ? `<p class="timeline-description">${_getText(item.description)}</p>` : ''}
-                        ${item.responsibilities ? `<p class="timeline-responsibilities"><strong>${labels.responsibilities}:</strong> ${_getText(item.responsibilities)}</p>` : ''}
+                        <p class="timeline-role">${_esc(_getText(item.role))}</p>
+                        ${item.companyDescription ? `<p class="timeline-company-desc">${_esc(_getText(item.companyDescription))}</p>` : ''}
+                        ${item.description ? `<p class="timeline-description">${_esc(_getText(item.description))}</p>` : ''}
+                        ${item.responsibilities ? `<p class="timeline-responsibilities"><strong>${labels.responsibilities}:</strong> ${_esc(_getText(item.responsibilities))}</p>` : ''}
                         ${renderScale(item.scale)}
                         ${renderAchievements(item.achievements)}
                         ${item.note ? `<div class="timeline-note"><p>${_getText(item.note)}</p></div>` : ''}
-                        ${item.leaveReason ? `<p class="timeline-leave-reason"><strong>${labels.leaveReason}:</strong> ${_getText(item.leaveReason)}</p>` : ''}
+                        ${item.leaveReason ? `<p class="timeline-leave-reason"><strong>${labels.leaveReason}:</strong> ${_esc(_getText(item.leaveReason))}</p>` : ''}
                         ${renderRelatedProjects(item.relatedProjects)}
                         ${item.tags ? `<div class="timeline-tags">${renderTags(item.tags)}</div>` : ''}
                     </div>
@@ -546,10 +561,10 @@ function renderExpertise(data, container) {
                         <div class="expertise-category">
                             <h3 class="expertise-title">
                                 <span class="expertise-icon">${iconMap[cat.icon] || '📌'}</span>
-                                ${_getText(cat.title)}
+                                ${_esc(_getText(cat.title))}
                             </h3>
                             <div class="tech-tags">
-                                ${cat.tags.map(tag => `<span class="tag">${tag}</span>`).join('')}
+                                ${cat.tags.map(tag => `<span class="tag">${_esc(tag)}</span>`).join('')}
                             </div>
                         </div>
                     `;
@@ -559,7 +574,7 @@ function renderExpertise(data, container) {
                     <div class="expertise-category">
                         <h3 class="expertise-title">
                             <span class="expertise-icon">${iconMap[cat.icon] || '📌'}</span>
-                            ${_getText(cat.title)}
+                            ${_esc(_getText(cat.title))}
                         </h3>
                         <ul class="expertise-list">
                             ${items.map(item => `<li>${_getText(item)}</li>`).join('')}
@@ -586,8 +601,8 @@ function renderLifecycleDetails(data, container) {
     container.innerHTML = data.lifecycleDetails.map(item => `
         <div class="lifecycle-card">
             <div class="lifecycle-icon">${iconMap[item.icon] || '📌'}</div>
-            <h4>${_getText(item.title)}</h4>
-            <p>${_getText(item.description)}</p>
+            <h4>${_esc(_getText(item.title))}</h4>
+            <p>${_esc(_getText(item.description))}</p>
         </div>
     `).join('');
 }
@@ -610,9 +625,9 @@ function renderManager(data, container) {
                 ${highlights.map(h => `
                     <div class="manager-highlight-card">
                         <div class="highlight-icon">${getIcon(h.icon)}</div>
-                        <div class="manager-highlight-value">${_getText(h.value)}</div>
-                        <div class="manager-highlight-label">${_getText(h.label)}</div>
-                        <div class="manager-highlight-description">${_getText(h.description)}</div>
+                        <div class="manager-highlight-value">${_esc(_getText(h.value))}</div>
+                        <div class="manager-highlight-label">${_esc(_getText(h.label))}</div>
+                        <div class="manager-highlight-description">${_esc(_getText(h.description))}</div>
                     </div>
                 `).join('')}
             </div>
@@ -622,7 +637,7 @@ function renderManager(data, container) {
     // Render PM Capabilities
     const renderCapabilities = (capabilities) => {
         const renderBadges = (items) =>
-            (items || []).filter(Boolean).map(text => `<span class="metric-badge">${text}</span>`).join('');
+            (items || []).filter(Boolean).map(text => `<span class="metric-badge">${_esc(text)}</span>`).join('');
 
         return capabilities.map(cap => {
             const badges = [];
@@ -660,11 +675,11 @@ function renderManager(data, container) {
             return `
                 <div class="manager-capability-card">
                     <div class="capability-icon">${getIcon(cap.icon)}</div>
-                    <h3 class="capability-title">${_getText(cap.title)}</h3>
-                    <p class="capability-description">${_getText(cap.description)}</p>
+                    <h3 class="capability-title">${_esc(_getText(cap.title))}</h3>
+                    <p class="capability-description">${_esc(_getText(cap.description))}</p>
                     ${highlights && highlights.length > 0 ? `
                         <ul class="capability-highlights">
-                            ${highlights.map(h => `<li>${h}</li>`).join('')}
+                            ${highlights.map(h => `<li>${_esc(h)}</li>`).join('')}
                         </ul>
                     ` : ''}
                     ${badges.length > 0 ? `<div class="capability-metrics">${renderBadges(badges)}</div>` : ''}
@@ -679,12 +694,12 @@ function renderManager(data, container) {
         const principles = _getArray(style.principles);
         return `
             <div class="leadership-style-section">
-                <h3 class="subsection-title">${_getText(style.title)}</h3>
+                <h3 class="subsection-title">${_esc(_getText(style.title))}</h3>
                 <div class="leadership-principles">
                     ${principles.map(p => `
                         <div class="principle-item">
                             <span class="principle-icon">✓</span>
-                            <span>${p}</span>
+                            <span>${_esc(p)}</span>
                         </div>
                     `).join('')}
                 </div>
@@ -702,24 +717,24 @@ function renderManager(data, container) {
                 <h3 class="subsection-title">${lang === 'ko' ? '비즈니스 임팩트' : 'Business Impact'}</h3>
                 <div class="impact-numbers">
                     <div class="impact-number">
-                        <span class="number">${numbers.certifications}</span>
+                        <span class="number">${_esc(numbers.certifications)}</span>
                         <span class="label">${lang === 'ko' ? '글로벌 인증' : 'Global Certs'}</span>
                     </div>
                     <div class="impact-number">
-                        <span class="number">${numbers.ipos}</span>
+                        <span class="number">${_esc(numbers.ipos)}</span>
                         <span class="label">${lang === 'ko' ? 'IPO 기여' : 'IPO Contrib'}</span>
                     </div>
                     <div class="impact-number">
-                        <span class="number">${numbers.performanceImprovement}</span>
+                        <span class="number">${_esc(numbers.performanceImprovement)}</span>
                         <span class="label">${lang === 'ko' ? '성능 향상' : 'Performance'}</span>
                     </div>
                     <div class="impact-number">
-                        <span class="number">${numbers.projectsDelivered}</span>
+                        <span class="number">${_esc(numbers.projectsDelivered)}</span>
                         <span class="label">${lang === 'ko' ? '프로젝트 납품' : 'Projects'}</span>
                     </div>
                 </div>
                 <ul class="impact-highlights">
-                    ${highlights.map(h => `<li>${h}</li>`).join('')}
+                    ${highlights.map(h => `<li>${_esc(h)}</li>`).join('')}
                 </ul>
             </div>
         `;
@@ -735,7 +750,7 @@ function renderManager(data, container) {
                     ${skills.map(skill => `
                         <div class="soft-skill-item">
                             <div class="skill-icon">${getIcon(skill.icon)}</div>
-                            <span class="skill-name">${_getText(skill.title)}</span>
+                            <span class="skill-name">${_esc(_getText(skill.title))}</span>
                             <div class="skill-level">
                                 ${Array(5).fill(0).map((_, i) => `<span class="level-dot ${i < skill.level ? 'filled' : ''}"></span>`).join('')}
                             </div>
@@ -781,11 +796,11 @@ function renderEducation(data, container) {
     const items = data.items.map(item => `
         <article class="education-item">
             <header class="education-header">
-                <h3 class="education-institution">${_getText(item.institution)}</h3>
-                <span class="education-period">${item.period || ''}</span>
+                <h3 class="education-institution">${_esc(_getText(item.institution))}</h3>
+                <span class="education-period">${_esc(item.period || '')}</span>
             </header>
-            ${item.degree ? `<p class="education-degree">${_getText(item.degree)}</p>` : ''}
-            ${item.location ? `<p class="education-location">${_getText(item.location)}</p>` : ''}
+            ${item.degree ? `<p class="education-degree">${_esc(_getText(item.degree))}</p>` : ''}
+            ${item.location ? `<p class="education-location">${_esc(_getText(item.location))}</p>` : ''}
         </article>
     `).join('');
     container.innerHTML = items;
@@ -821,31 +836,31 @@ function renderCompensation(data, container) {
 
     const currentBlock = data.currentPackage ? `
         <div class="compensation-block">
-            <h4 class="compensation-block-title">${_getText(data.currentPackage.label)}</h4>
+            <h4 class="compensation-block-title">${_esc(_getText(data.currentPackage.label))}</h4>
             <ul class="compensation-component-list">
                 ${(data.currentPackage.components || []).map(c => `
                     <li>
-                        <span class="compensation-component-label">${_getText(c.label)}</span>
-                        <span class="compensation-component-value">${c.value || ''}</span>
+                        <span class="compensation-component-label">${_esc(_getText(c.label))}</span>
+                        <span class="compensation-component-value">${_esc(c.value || '')}</span>
                     </li>
                 `).join('')}
             </ul>
             ${data.currentPackage.estimatedAnnualEv ? `
-                <p class="compensation-ev"><strong>${sectionLabels.evTerm}:</strong> ${_getText(data.currentPackage.estimatedAnnualEv)}</p>
+                <p class="compensation-ev"><strong>${sectionLabels.evTerm}:</strong> ${_esc(_getText(data.currentPackage.estimatedAnnualEv))}</p>
             ` : ''}
         </div>
     ` : '';
 
     const marketBlock = data.marketBaseline ? `
         <div class="compensation-block">
-            <h4 class="compensation-block-title">${_getText(data.marketBaseline.label)}</h4>
+            <h4 class="compensation-block-title">${_esc(_getText(data.marketBaseline.label))}</h4>
             ${data.marketBaseline.anchor ? `
-                <p class="compensation-anchor"><strong>${sectionLabels.anchorTerm}:</strong> ${_getText(data.marketBaseline.anchor)}</p>
+                <p class="compensation-anchor"><strong>${sectionLabels.anchorTerm}:</strong> ${_esc(_getText(data.marketBaseline.anchor))}</p>
             ` : ''}
             ${Array.isArray(data.marketBaseline.evidence) && data.marketBaseline.evidence.length ? `
                 <p class="compensation-evidence-label">${sectionLabels.evidenceTerm}</p>
                 <ul class="compensation-evidence-list">
-                    ${data.marketBaseline.evidence.map(e => `<li>${_getText(e)}</li>`).join('')}
+                    ${data.marketBaseline.evidence.map(e => `<li>${_esc(_getText(e))}</li>`).join('')}
                 </ul>
             ` : ''}
         </div>
@@ -856,19 +871,19 @@ function renderCompensation(data, container) {
             <h4 class="compensation-block-title">${sectionLabels.tiers}</h4>
             <div class="compensation-tier-grid">
                 ${data.tiers.map(tier => `
-                    <article class="compensation-tier compensation-tier--${tier.tone || tier.id || 'default'}">
+                    <article class="compensation-tier compensation-tier--${_esc(tier.tone || tier.id || 'default')}">
                         <header class="compensation-tier-header">
-                            <h5 class="compensation-tier-label">${_getText(tier.label)}</h5>
+                            <h5 class="compensation-tier-label">${_esc(_getText(tier.label))}</h5>
                         </header>
                         <dl class="compensation-tier-details">
-                            <dt>${sectionLabels.baseTerm}</dt><dd>${_getText(tier.base)}</dd>
-                            <dt>${sectionLabels.signingTerm}</dt><dd>${_getText(tier.signing)}</dd>
-                            <dt>${sectionLabels.incentiveTerm}</dt><dd>${_getText(tier.incentive)}</dd>
-                            <dt>${sectionLabels.optionsTerm}</dt><dd>${_getText(tier.options)}</dd>
-                            <dt>${sectionLabels.totalTerm}</dt><dd class="compensation-tier-total">${_getText(tier.totalFirstYear)}</dd>
+                            <dt>${sectionLabels.baseTerm}</dt><dd>${_esc(_getText(tier.base))}</dd>
+                            <dt>${sectionLabels.signingTerm}</dt><dd>${_esc(_getText(tier.signing))}</dd>
+                            <dt>${sectionLabels.incentiveTerm}</dt><dd>${_esc(_getText(tier.incentive))}</dd>
+                            <dt>${sectionLabels.optionsTerm}</dt><dd>${_esc(_getText(tier.options))}</dd>
+                            <dt>${sectionLabels.totalTerm}</dt><dd class="compensation-tier-total">${_esc(_getText(tier.totalFirstYear))}</dd>
                         </dl>
                         ${tier.rationale ? `
-                            <p class="compensation-tier-rationale"><strong>${sectionLabels.rationaleTerm}:</strong> ${_getText(tier.rationale)}</p>
+                            <p class="compensation-tier-rationale"><strong>${sectionLabels.rationaleTerm}:</strong> ${_esc(_getText(tier.rationale))}</p>
                         ` : ''}
                     </article>
                 `).join('')}
@@ -880,7 +895,7 @@ function renderCompensation(data, container) {
         <div class="compensation-block">
             <h4 class="compensation-block-title">${sectionLabels.nonNegotiables}</h4>
             <ul class="compensation-non-negotiables">
-                ${data.nonNegotiables.map(n => `<li>${_getText(n)}</li>`).join('')}
+                ${data.nonNegotiables.map(n => `<li>${_esc(_getText(n))}</li>`).join('')}
             </ul>
         </div>
     ` : '';
@@ -888,22 +903,22 @@ function renderCompensation(data, container) {
     const stanceBlock = data.negotiationStance ? `
         <div class="compensation-block compensation-block--stance">
             <h4 class="compensation-block-title">${sectionLabels.stance}</h4>
-            <p>${_getText(data.negotiationStance)}</p>
+            <p>${_esc(_getText(data.negotiationStance))}</p>
         </div>
     ` : '';
 
     const visibilityNote = data.visibility ? `
-        <p class="compensation-visibility-note">${_getText(data.visibility)}</p>
+        <p class="compensation-visibility-note">${_esc(_getText(data.visibility))}</p>
     ` : '';
 
     const lastUpdated = data.lastUpdated ? `
-        <p class="compensation-meta">${sectionLabels.updatedTerm}: ${data.lastUpdated}</p>
+        <p class="compensation-meta">${sectionLabels.updatedTerm}: ${_esc(data.lastUpdated)}</p>
     ` : '';
 
     container.innerHTML = `
-        <h2 class="section-title">${_getText(data.title)}</h2>
-        ${data.subtitle ? `<p class="section-subtitle">${_getText(data.subtitle)}</p>` : ''}
-        ${data.intro ? `<p class="compensation-intro">${_getText(data.intro)}</p>` : ''}
+        <h2 class="section-title">${_esc(_getText(data.title))}</h2>
+        ${data.subtitle ? `<p class="section-subtitle">${_esc(_getText(data.subtitle))}</p>` : ''}
+        ${data.intro ? `<p class="compensation-intro">${_esc(_getText(data.intro))}</p>` : ''}
         ${visibilityNote}
         <details class="compensation-details">
             <summary class="compensation-summary">

--- a/portfolio/data/data.js
+++ b/portfolio/data/data.js
@@ -6,7 +6,7 @@
 (async function() {
   const DATA_BASE_PATH = 'data';
   // Bump on every content change to invalidate browser/CDN caches.
-  const DATA_VERSION = '3.0.0';
+  const DATA_VERSION = '3.1.0';
   const PRIVATE_ACCESS_KEY = 'kcenon.private.access';
   const PRIVATE_ACCESS_TOKEN = 'enabled';
 

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -20,7 +20,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=3.0.0">
+    <link rel="stylesheet" href="styles.css?v=3.1.0">
 </head>
 <body>
     <!-- Navigation -->
@@ -451,9 +451,9 @@
     </footer>
 
     <!-- Scripts -->
-    <script src="data/data.js?v=3.0.0"></script>
-    <script src="utils/i18n.js?v=3.0.0"></script>
-    <script src="components/components.js?v=3.0.0"></script>
-    <script src="script.js?v=3.0.0"></script>
+    <script src="data/data.js?v=3.1.0"></script>
+    <script src="utils/i18n.js?v=3.1.0"></script>
+    <script src="components/components.js?v=3.1.0"></script>
+    <script src="script.js?v=3.1.0"></script>
 </body>
 </html>

--- a/portfolio/script.js
+++ b/portfolio/script.js
@@ -292,6 +292,12 @@ const translations = {
     }
 };
 
+// Translation keys whose values intentionally contain HTML and must be rendered
+// via innerHTML: hero.summary uses <strong> emphasis, footer.copyright uses the
+// &copy; entity. Every other key is plain text and is rendered via textContent
+// so stray '<' or '&' in translations can never break markup or inject HTML.
+const HTML_I18N_KEYS = new Set(['hero.summary', 'footer.copyright']);
+
 let currentLang = localStorage.getItem('lang') || 'ko';
 
 function setMetaContent(selector, content) {
@@ -347,11 +353,18 @@ function setLanguage(lang) {
         langToggle.textContent = lang === 'ko' ? 'EN' : 'KO';
     }
 
-    // Update all elements with data-i18n attribute
+    // Update all elements with data-i18n attribute.
+    // innerHTML is limited to the HTML_I18N_KEYS allowlist; all other keys are
+    // plain text and use textContent (see HTML_I18N_KEYS comment above).
     document.querySelectorAll('[data-i18n]').forEach(el => {
         const key = el.getAttribute('data-i18n');
         if (translations[lang] && translations[lang][key]) {
-            el.innerHTML = interpolateTemplate(translations[lang][key]);
+            const value = interpolateTemplate(translations[lang][key]);
+            if (HTML_I18N_KEYS.has(key)) {
+                el.innerHTML = value;
+            } else {
+                el.textContent = value;
+            }
         }
     });
 

--- a/portfolio/utils/i18n.js
+++ b/portfolio/utils/i18n.js
@@ -102,6 +102,23 @@ function formatPeriodWithDuration(period) {
 }
 
 /**
+ * Escape HTML special characters for safe interpolation into innerHTML templates
+ * Replaces &, <, >, ", ' with their HTML entities. Applied exactly once at the
+ * interpolation site — input data must contain raw (unescaped) text.
+ * @param {*} str - Raw value (non-strings are coerced; null/undefined yield '')
+ * @returns {string} HTML-escaped string
+ */
+function escapeHtml(str) {
+    if (str === null || str === undefined) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+/**
  * Get translated text from translations object
  * @param {string} key - Translation key (e.g., 'nav.about')
  * @returns {string} Translated text or key if not found
@@ -118,6 +135,7 @@ window.i18nUtils = {
     getArray,
     calculateDuration,
     formatPeriodWithDuration,
+    escapeHtml,
     t
 };
 
@@ -127,3 +145,4 @@ window.getText = getText;
 window.getArray = getArray;
 window.calculateDuration = calculateDuration;
 window.formatPeriodWithDuration = formatPeriodWithDuration;
+window.escapeHtml = escapeHtml;

--- a/tools/export-snapshot.mjs
+++ b/tools/export-snapshot.mjs
@@ -1,0 +1,455 @@
+/**
+ * Export Snapshot Harness
+ * =======================
+ *
+ * Regression safety net for refactoring the admin PDF/DOCX exporters.
+ * It loads the browser exporter scripts unmodified inside Node, builds the
+ * document definitions exactly the way the admin export flow does (default
+ * options: all public sections, cover page on, cover letter off, executive
+ * theme, compensation/private excluded), and serializes them to
+ * deterministic JSON snapshots:
+ *
+ *   pdf-ko.json   pdfmake docDefinition, Korean
+ *   pdf-en.json   pdfmake docDefinition, English
+ *   docx-ko.json  docx.js Document object tree, Korean
+ *   docx-en.json  docx.js Document object tree, English
+ *
+ * Usage
+ * -----
+ *   # 1) Baseline mode: generate/overwrite baseline snapshots
+ *   node tools/export-snapshot.mjs baseline [--dir <snapshot-dir>]
+ *
+ *   # 2) Compare mode: rebuild with the CURRENT code and diff against the
+ *   #    baseline; prints a per-snapshot diff summary. Exit code 0 = no
+ *   #    differences, 1 = differences found (or missing baseline files).
+ *   node tools/export-snapshot.mjs compare [--dir <snapshot-dir>]
+ *
+ * Default snapshot dir: <repo>/tools/export-baseline (override with --dir).
+ *
+ * Determinism
+ * -----------
+ * - Date is frozen (fixed timestamp) so the cover-page date, "Present"
+ *   duration math, and docx core-properties timestamps are stable.
+ * - Math.random is replaced with a seeded PRNG (docx.umd.js derives some
+ *   internal IDs from it); the PRNG is re-seeded before each build.
+ * - Builds always run in the same order (pdf-ko, pdf-en, docx-ko, docx-en)
+ *   so module-level counters inside docx.umd.js line up across runs.
+ * - Serialization uses sorted object keys, a cycle guard, a depth limit,
+ *   and records constructor names ($type) for class instances.
+ * - The PDF exporter's font state is forced to "loaded" so no network
+ *   fetch happens and defaultStyle.font matches a successful browser run.
+ *
+ * The exporter sources are loaded as-is (classic scripts via node:vm);
+ * this harness never modifies them.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+process.env.TZ = process.env.TZ || 'Asia/Seoul';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const PORTFOLIO = path.join(REPO_ROOT, 'portfolio');
+
+const SNAPSHOT_NAMES = ['pdf-ko', 'pdf-en', 'docx-ko', 'docx-en'];
+
+// Sections used by the default admin export flow (compensation excluded).
+const DEFAULT_SECTIONS = ['expertise', 'manager', 'projects', 'career', 'education', 'testimonials'];
+
+// ---------------------------------------------------------------------------
+// Determinism: frozen Date + seeded Math.random
+// ---------------------------------------------------------------------------
+
+const RealDate = Date;
+// Fixed reference time: 2026-08-01 12:00:00 (local TZ, pinned to Asia/Seoul).
+const FIXED_NOW_MS = new RealDate(2026, 7, 1, 12, 0, 0).getTime();
+
+class FrozenDate extends RealDate {
+  constructor(...args) {
+    if (args.length === 0) {
+      super(FIXED_NOW_MS);
+    } else {
+      super(...args);
+    }
+  }
+  static now() {
+    return FIXED_NOW_MS;
+  }
+}
+
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const RANDOM_SEED = 0xC0FFEE;
+let rng = mulberry32(RANDOM_SEED);
+
+/** Reset all mutable determinism state before each build. */
+function resetDeterminism() {
+  rng = mulberry32(RANDOM_SEED);
+}
+
+// ---------------------------------------------------------------------------
+// Browser environment stubs (must exist before the classic scripts load)
+// ---------------------------------------------------------------------------
+
+function installBrowserStubs() {
+  globalThis.window = globalThis;
+  globalThis.self = globalThis;
+  globalThis.Date = FrozenDate;
+  Math.random = () => rng();
+
+  // Minimal Map-based localStorage stub (Web Storage subset the code uses).
+  const store = new Map();
+  const localStorageStub = {
+    getItem: (k) => (store.has(String(k)) ? store.get(String(k)) : null),
+    setItem: (k, v) => { store.set(String(k), String(v)); },
+    removeItem: (k) => { store.delete(String(k)); },
+    clear: () => { store.clear(); },
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size; }
+  };
+  try {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: localStorageStub, configurable: true, writable: true
+    });
+  } catch {
+    globalThis.localStorage = localStorageStub;
+  }
+}
+
+/** Load a classic (non-module) browser script into the shared global scope. */
+function loadClassicScript(relPath) {
+  const abs = path.join(PORTFOLIO, relPath);
+  const code = fs.readFileSync(abs, 'utf8');
+  vm.runInThisContext(code, { filename: abs });
+}
+
+function loadExporterScripts() {
+  // Same relative order as admin.html: shared utils first, then vendor
+  // docx, then the exporters. pdfmake is NOT needed (buildDocument only).
+  loadClassicScript('utils/i18n.js');
+  loadClassicScript('admin/utils/export-content.js');
+  loadClassicScript('admin/utils/export-ir.js');
+  loadClassicScript('admin/utils/theme-config.js');
+  loadClassicScript('admin/utils/style-manager.js');
+  loadClassicScript('admin/vendor/docx.umd.js');
+  loadClassicScript('admin/utils/docx-exporter.js');
+  loadClassicScript('admin/utils/pdf-exporter.js');
+}
+
+// ---------------------------------------------------------------------------
+// Portfolio data (mirrors data.js -> window.PortfolioData and admin.js this.data)
+// ---------------------------------------------------------------------------
+
+function loadPortfolioData() {
+  const dataDir = path.join(PORTFOLIO, 'data');
+  const load = (f) => JSON.parse(fs.readFileSync(path.join(dataDir, f), 'utf8'));
+
+  // Same shape data.js builds into window.PortfolioData. compensation lives
+  // in data/private/ and is only loaded with private access — snapshot runs
+  // mirror the default (no-access) session, so it stays null.
+  const portfolioData = {
+    projects: load('projects.json'),
+    career: load('career.json'),
+    expertise: load('expertise.json'),
+    testimonials: load('testimonials.json'),
+    manager: load('manager.json'),
+    coverLetter: load('cover-letter.json'),
+    education: load('education.json'),
+    profile: load('profile.json'),
+    compensation: null
+  };
+  globalThis.window.PortfolioData = portfolioData;
+
+  // admin.js AdminApp.this.data mirror (subset passed to the exporters).
+  return {
+    projects: portfolioData.projects,
+    manager: portfolioData.manager,
+    career: portfolioData.career,
+    expertise: portfolioData.expertise,
+    testimonials: portfolioData.testimonials,
+    education: portfolioData.education,
+    profile: portfolioData.profile
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Document builds (default admin export flow, no file download)
+// ---------------------------------------------------------------------------
+
+/** Info object generatePDF/generateDOCX derive from their default options. */
+function buildInfo(lang) {
+  return {
+    title: lang === 'ko' ? '포트폴리오' : 'Portfolio',
+    author: lang === 'ko' ? '신동철' : 'Dongcheol Shin',
+    includeCoverLetter: false,
+    coverLetterTemplate: null,
+    includeCoverPage: true,
+    pageBreakBetweenSections: true,
+    personalInfoFields: []
+  };
+}
+
+function buildPdfDocDefinition(data, lang) {
+  resetDeterminism();
+  const exporter = globalThis.window.PDFExporter;
+  exporter.currentLang = lang;
+  exporter.initializeTheme('executive', {});
+  // Skip the network font fetch: mark the Korean font as loaded so
+  // defaultStyle.font matches a successful loadKoreanFont() browser run.
+  exporter.fontLoaded = true;
+  return exporter.buildDocument(data, DEFAULT_SECTIONS, buildInfo(lang));
+}
+
+function buildDocxDocument(data, lang) {
+  resetDeterminism();
+  const exporter = globalThis.window.DOCXExporter;
+  exporter.currentLang = lang;
+  exporter.initializeTheme('executive', {});
+  return exporter.buildDocument(data, DEFAULT_SECTIONS, buildInfo(lang));
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic serialization
+// ---------------------------------------------------------------------------
+
+const MAX_DEPTH = 80;
+
+/**
+ * Convert an arbitrary object tree (including class instances) into a plain
+ * JSON-safe tree: sorted keys, $type markers for class instances, cycle
+ * guard, depth limit, and stable markers for non-JSON values.
+ */
+function toSerializableTree(value, depth = 0, ancestors = new Set()) {
+  if (value === null) return null;
+  const t = typeof value;
+  if (t === 'string' || t === 'boolean') return value;
+  if (t === 'number') {
+    return Number.isFinite(value) ? value : `[Number ${String(value)}]`;
+  }
+  if (t === 'bigint') return `[BigInt ${value.toString()}]`;
+  if (t === 'undefined') return '[undefined]';
+  if (t === 'function') return `[Function ${value.name || 'anonymous'}]`;
+  if (t === 'symbol') return `[Symbol ${String(value.description || '')}]`;
+
+  // Objects from here on.
+  if (ancestors.has(value)) return '[Circular]';
+  if (depth > MAX_DEPTH) return '[MaxDepth]';
+
+  if (value instanceof RealDate) {
+    return `[Date ${new RealDate(value.getTime()).toISOString()}]`;
+  }
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+    const len = value.byteLength ?? value.length ?? 0;
+    return `[${value.constructor?.name || 'Bytes'} byteLength=${len}]`;
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item) =>
+        item === undefined ? null : toSerializableTree(item, depth + 1, ancestors));
+    }
+    if (value instanceof Map) {
+      return {
+        $type: 'Map',
+        entries: Array.from(value.entries()).map(([k, v]) => [
+          toSerializableTree(k, depth + 1, ancestors),
+          toSerializableTree(v, depth + 1, ancestors)
+        ])
+      };
+    }
+    if (value instanceof Set) {
+      return {
+        $type: 'Set',
+        values: Array.from(value.values()).map((v) =>
+          toSerializableTree(v, depth + 1, ancestors))
+      };
+    }
+
+    const out = {};
+    const ctor = value.constructor?.name;
+    if (ctor && ctor !== 'Object') out.$type = ctor;
+    for (const key of Object.keys(value).sort()) {
+      const v = value[key];
+      if (v === undefined) continue;
+      out[key] = toSerializableTree(v, depth + 1, ancestors);
+    }
+    return out;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function serializeSnapshot(root) {
+  return JSON.stringify(toSerializableTree(root), null, 2) + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Structural diff (compare mode)
+// ---------------------------------------------------------------------------
+
+const MAX_DIFFS_PER_SNAPSHOT = 40;
+
+function preview(v) {
+  let s;
+  try { s = JSON.stringify(v); } catch { s = String(v); }
+  if (s === undefined) s = String(v);
+  return s.length > 120 ? s.slice(0, 117) + '...' : s;
+}
+
+function collectDiffs(a, b, p, diffs) {
+  if (diffs.length >= MAX_DIFFS_PER_SNAPSHOT) return;
+  if (a === b) return;
+  const aArr = Array.isArray(a);
+  const bArr = Array.isArray(b);
+  const aObj = a !== null && typeof a === 'object';
+  const bObj = b !== null && typeof b === 'object';
+
+  if (aArr !== bArr || aObj !== bObj) {
+    diffs.push(`${p}: type changed  baseline=${preview(a)}  current=${preview(b)}`);
+    return;
+  }
+  if (aArr) {
+    if (a.length !== b.length) {
+      diffs.push(`${p}: array length ${a.length} -> ${b.length}`);
+    }
+    const n = Math.min(a.length, b.length);
+    for (let i = 0; i < n && diffs.length < MAX_DIFFS_PER_SNAPSHOT; i++) {
+      collectDiffs(a[i], b[i], `${p}[${i}]`, diffs);
+    }
+    return;
+  }
+  if (aObj) {
+    const keys = Array.from(new Set([...Object.keys(a), ...Object.keys(b)])).sort();
+    for (const k of keys) {
+      if (diffs.length >= MAX_DIFFS_PER_SNAPSHOT) return;
+      const kp = `${p}.${k}`;
+      if (!(k in a)) { diffs.push(`${kp}: added  current=${preview(b[k])}`); continue; }
+      if (!(k in b)) { diffs.push(`${kp}: removed  baseline=${preview(a[k])}`); continue; }
+      collectDiffs(a[k], b[k], kp, diffs);
+    }
+    return;
+  }
+  diffs.push(`${p}: ${preview(a)} -> ${preview(b)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot validation (sanity checks for baseline mode)
+// ---------------------------------------------------------------------------
+
+const HANGUL_RE = /[가-힣]/;
+
+function validateSnapshot(name, json) {
+  const problems = [];
+  if (json.length < 10000) {
+    problems.push(`suspiciously small (${json.length} bytes)`);
+  }
+  const lang = name.endsWith('-ko') ? 'ko' : 'en';
+  if (lang === 'ko' && !HANGUL_RE.test(json)) {
+    problems.push('no Hangul text found in Korean snapshot');
+  }
+  if (lang === 'en' && !/EXPERTISE|PROJECTS|CAREER/.test(json)) {
+    problems.push('no English section labels found in English snapshot');
+  }
+  return problems;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { mode: argv[2], dir: path.join(REPO_ROOT, 'tools', 'export-baseline') };
+  for (let i = 3; i < argv.length; i++) {
+    if (argv[i] === '--dir' && argv[i + 1]) {
+      args.dir = path.resolve(argv[++i]);
+    } else {
+      console.error(`Unknown argument: ${argv[i]}`);
+      process.exit(2);
+    }
+  }
+  if (args.mode !== 'baseline' && args.mode !== 'compare') {
+    console.error('Usage: node tools/export-snapshot.mjs <baseline|compare> [--dir <snapshot-dir>]');
+    process.exit(2);
+  }
+  return args;
+}
+
+function buildAllSnapshots() {
+  installBrowserStubs();
+  loadExporterScripts();
+  const data = loadPortfolioData();
+
+  // Fixed build order — keep in sync with the determinism notes above.
+  return {
+    'pdf-ko': serializeSnapshot(buildPdfDocDefinition(data, 'ko')),
+    'pdf-en': serializeSnapshot(buildPdfDocDefinition(data, 'en')),
+    'docx-ko': serializeSnapshot(buildDocxDocument(data, 'ko')),
+    'docx-en': serializeSnapshot(buildDocxDocument(data, 'en'))
+  };
+}
+
+function main() {
+  const { mode, dir } = parseArgs(process.argv);
+  const snapshots = buildAllSnapshots();
+
+  if (mode === 'baseline') {
+    fs.mkdirSync(dir, { recursive: true });
+    let failed = false;
+    for (const name of SNAPSHOT_NAMES) {
+      const json = snapshots[name];
+      const file = path.join(dir, `${name}.json`);
+      fs.writeFileSync(file, json, 'utf8');
+      const problems = validateSnapshot(name, json);
+      const status = problems.length === 0 ? 'OK' : `WARN (${problems.join('; ')})`;
+      if (problems.length > 0) failed = true;
+      console.log(`baseline ${name}.json  ${Buffer.byteLength(json, 'utf8')} bytes  ${status}`);
+    }
+    console.log(`Baseline written to: ${dir}`);
+    process.exit(failed ? 1 : 0);
+  }
+
+  // compare mode
+  let totalDiffs = 0;
+  let missing = 0;
+  for (const name of SNAPSHOT_NAMES) {
+    const file = path.join(dir, `${name}.json`);
+    if (!fs.existsSync(file)) {
+      console.log(`${name}: MISSING baseline (${file})`);
+      missing++;
+      continue;
+    }
+    const baselineText = fs.readFileSync(file, 'utf8');
+    const currentText = snapshots[name];
+    if (baselineText === currentText) {
+      console.log(`${name}: identical`);
+      continue;
+    }
+    const diffs = [];
+    collectDiffs(JSON.parse(baselineText), JSON.parse(currentText), '$', diffs);
+    totalDiffs += diffs.length;
+    const capped = diffs.length >= MAX_DIFFS_PER_SNAPSHOT ? ' (capped)' : '';
+    console.log(`${name}: ${diffs.length} difference(s)${capped}`);
+    for (const d of diffs) console.log(`  ${d}`);
+  }
+  if (missing > 0 || totalDiffs > 0) {
+    console.log(`Compare result: ${totalDiffs} difference(s), ${missing} missing baseline file(s).`);
+    process.exit(1);
+  }
+  console.log('Compare result: all snapshots identical.');
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## What

Applies the four follow-up items deferred from the audit cleanup (#27): exporter IR unification, Korean bold in PDF, preview/export parity, and HTML escaping in the public renderers.

## Changes

- **Exporter IR unification**: new `export-ir.js` builds a format-neutral node tree that single-sources every content decision (section order, fields, labels via ExportContent); the docx and pdf exporters are now IR walkers that keep only format-side styling, fonts, and themes. All 31 duplicated build methods migrated 1:1; one dead method removed.
- **Korean bold in PDF**: `loadKoreanFont` fetches NotoSansKR Regular and Bold in parallel; bold/bolditalics now map to the Bold face, restoring visual hierarchy in Korean PDFs. Bold-only failure falls back to regular weight and surfaces a warning toast.
- **Preview parity**: the admin preview renders the manager section (previously empty), localizes section titles, renders the cover page and cover letter with the exporters' template resolution, and matches the exporters' page-break rule.
- **HTML escaping**: shared `escapeHtml` in `utils/i18n.js`; the public renderers escape all data-derived text/attribute interpolations (84 sites) with an http(s) guard on hrefs; `setLanguage` uses `textContent` except two allowlisted HTML keys. Four authored-markup JSON fields remain unescaped by design, documented at the helper.
- Unified cache version bumped to 3.1.0.

## Verification

- Snapshot regression harness (`tools/export-snapshot.mjs`, committed): pre-refactor baselines vs post-refactor output — pdf ko/en show zero content diff; docx ko/en diffs are limited to normalizing an invalid `keepNext` OOXML boolean carried by the legacy code (56 occurrences per language, single diff type, no text loss).
- Three independent verifier passes (regression, content coverage vs main, escaping audit) reported no high-severity issues.
- `node --check` passes on all changed files; `tools/check-cache-versions.sh` OK at 3.1.0.

## Known accepted deltas

- Cover-letter-only exports (a path the current UI cannot reach) gain a consistent page-break rule that differs from legacy in both formats.
- Private `compensation.json` fields are now escaped like all other data; authored markup there (if any) would render literally.
